### PR TITLE
fix(Sample5): fix terraform errors

### DIFF
--- a/05-file-transfer-cloud/README.md
+++ b/05-file-transfer-cloud/README.md
@@ -35,7 +35,7 @@ It's as simple as running the main terraform script:
 
 ```bash
 cd 05-file-transfer-cloud/terraform 
-terraform init
+terraform init --upgrade
 terraform apply
 ```
 
@@ -99,7 +99,7 @@ java -Dedc.fs.config=05-file-transfer-cloud/cloud-transfer-provider/config.prope
 To request data offers from the provider, run:
 
 ```bash
-curl -X GET -H 'X-Api-Key: password' http://localhost:9191/api/control/catalog?provider=http://localhost:8282/api/v1/ids/data
+curl -X GET -H 'X-Api-Key: password' "http://localhost:9192/api/v1/management/catalog?providerUrl=http://localhost:8282/api/v1/ids/data"
 ```
 
 #### 3. Negotiate Contract
@@ -118,7 +118,7 @@ curl --location --request POST 'http://localhost:9192/api/v1/management/contract
   "offer": {
     "offerId": "1:3a75736e-001d-4364-8bd4-9888490edb58",
     "assetId": "1",
-    "policy": { <Copy one of the policy from contractoffer.json file in 04.0-file-transfer> }
+    "policy": { <Copy the first policy from the previous response (the one with "target: 1")> }
   }
 }'
 ```

--- a/05-file-transfer-cloud/terraform/main.tf
+++ b/05-file-transfer-cloud/terraform/main.tf
@@ -3,15 +3,15 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.88.1"
+      version = ">= 2.88.1"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "2.12.0"
+      version = ">= 2.12.0"
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "3.45.0"
+      version = ">= 3.45.0"
     }
   }
 }

--- a/05-file-transfer-cloud/terraform/test-document.txt
+++ b/05-file-transfer-cloud/terraform/test-document.txt
@@ -1,0 +1,1 @@
+Test file


### PR DESCRIPTION
## What this PR changes/adds

Fixes the errors in sample 5's Terraform script. Updates the providers and adds the missing test file.

## Further notes

- updated the catalog request URI in the `README`, as it was outdated and returned 404
- updated the `curl` command for initiating a negotiation, as this previously said to copy a policy from sample 4 (in which case the contract request would be superfluous)

## Linked Issue(s)

Closes #3

## Checklist

- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] documented code?
- [x] assigned appropriate label?
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Samples/blob/main/CONTRIBUTING.md#submit-a-pull-request) for details_)