### PR TITLE
fix: port values in the `README` in transfer-07

### DIFF
--- a/transfer/transfer-07-provider-push-http/README.md
+++ b/transfer/transfer-07-provider-push-http/README.md
@@ -85,8 +85,8 @@ java -Dedc.keystore=transfer/transfer-07-provider-push-http/certs/cert.pfx -Dedc
 ```
 
 Assuming you didn't change the ports in config files, the consumer will listen on the
-ports `29191`, `29192` (management API) and `29292` (IDS API) and the provider will listen on the
-ports `12181`, `19182` (management API) and `19282` (IDS API).
+ports `29191`, `29193` (management API) and `29194` (IDS API) and the provider will listen on the
+ports `19191`, `19193` (management API) and `19194` (IDS API).
 
 # Run the sample
 


### PR DESCRIPTION
## What this PR changes/adds

fix the port values of `Provider` and `Consumer` in README
## Why it does that

Match the port values in the configuration properties to the README
## Further notes


## Linked Issue(s)

Closes #38 

## Checklist

- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] documented code?
- [ ] assigned appropriate label?
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Samples/blob/main/CONTRIBUTING.md#submit-a-pull-request) for details_)