### PR TITLE
fix: stick to milestone8 version for catalog

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,7 +35,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("org.eclipse.edc:edc-versions:0.0.1-SNAPSHOT")
+            from("org.eclipse.edc:edc-versions:0.0.1-milestone-8")
             // this is not part of the published EDC Version Catalog, so we'll just "amend" it
             library(
                     "dnsOverHttps",


### PR DESCRIPTION
## What this PR changes/adds

stick version catalog to version `milestone-9`

## Why it does that

avoid compilation break

## Further notes

- likely we'll need to use version catalog in this project as well

## Linked Issue(s)

Closes #43 

## Checklist

- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] documented code?
- [x] assigned appropriate label?
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Samples/blob/main/CONTRIBUTING.md#submit-a-pull-request) for details_)