### PR TITLE
build: add libs.versions.toml for samples

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,25 @@
+[metadata]
+format.version = "1.1"
+
+
+[versions]
+assertj = "3.24.2"
+awaitility = "4.2.0"
+jupiter = "5.9.3"
+openTelemetry = "1.18.0"
+restAssured = "5.3.0"
+rsApi = "3.1.0"
+
+
+[libraries]
+assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
+jakarta-rsApi = { module = "jakarta.ws.rs:jakarta.ws.rs-api", version.ref = "rsApi" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "jupiter" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "jupiter" }
+opentelemetry-annotations = { module = "io.opentelemetry:opentelemetry-extension-annotations", version.ref = "openTelemetry" }
+restAssured = { module = "io.rest-assured:rest-assured", version.ref = "restAssured" }
+
+
+[plugins]
+shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/other/custom-runtime/build.gradle.kts
+++ b/other/custom-runtime/build.gradle.kts
@@ -37,8 +37,12 @@ application {
     mainClass.set("org.eclipse.edc.sample.runtime.CustomRuntime")
 }
 
+var distTar = tasks.getByName("distTar")
+var distZip = tasks.getByName("distZip")
+
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     exclude("**/pom.properties", "**/pom.xm")
     mergeServiceFiles()
     archiveFileName.set("custom-runtime.jar")
+    dependsOn(distTar, distZip)
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,17 +33,6 @@ dependencyResolutionManagement {
         mavenCentral()
         mavenLocal()
     }
-    versionCatalogs {
-        create("libs") {
-            from("org.eclipse.edc:edc-versions:0.0.1-milestone-8")
-            // this is not part of the published EDC Version Catalog, so we'll just "amend" it
-            library(
-                    "dnsOverHttps",
-                    "com.squareup.okhttp3",
-                    "okhttp-dnsoverhttps"
-            ).versionRef("okhttp")
-        }
-    }
 }
 
 // basic

--- a/transfer/transfer-06-consumer-pull-http/README.md
+++ b/transfer/transfer-06-consumer-pull-http/README.md
@@ -92,7 +92,7 @@ This property is used to define the endpoint exposed by the control plane to val
 To run a provider, you should run the following command
 
 ```bash
-java -Dedc.keystore=transfer/transfer-06-consumer-pull-http/certs/cert.pfx -Dedc.keystore.password=123456 -Dedc.vault=transfer/transfer-06-consumer-pull-http/http-pull-provider/provider-vault.properties -Dedc.fs.config=transfer/transfer-06-consumer-pull-http/http-pull-provider/provider-configuration.properties -jar transfer/transfer-06-consumer-pull-http/http-pull-connector/build/libs/http-pull-connector.jar
+java -Dedc.keystore=transfer/transfer-06-consumer-pull-http/certs/cert.pfx -Dedc.keystore.password=123456 -Dedc.vault=transfer/transfer-06-consumer-pull-http/http-pull-provider/provider-vault.properties -Dedc.fs.config=transfer/transfer-06-consumer-pull-http/http-pull-provider/provider-configuration.properties -jar transfer/transfer-06-consumer-pull-http/http-pull-connector/build/libs/pull-connector.jar
 ```
 
 ### 2. Run a consumer
@@ -100,7 +100,7 @@ java -Dedc.keystore=transfer/transfer-06-consumer-pull-http/certs/cert.pfx -Dedc
 To run a consumer, you should run the following command
 
 ```bash
-java -Dedc.keystore=transfer/transfer-06-consumer-pull-http/certs/cert.pfx -Dedc.keystore.password=123456 -Dedc.vault=transfer/transfer-06-consumer-pull-http/http-pull-consumer/consumer-vault.properties -Dedc.fs.config=transfer/transfer-06-consumer-pull-http/http-pull-consumer/consumer-configuration.properties -jar transfer/transfer-06-consumer-pull-http/http-pull-connector/build/libs/http-pull-connector.jar
+java -Dedc.keystore=transfer/transfer-06-consumer-pull-http/certs/cert.pfx -Dedc.keystore.password=123456 -Dedc.vault=transfer/transfer-06-consumer-pull-http/http-pull-consumer/consumer-vault.properties -Dedc.fs.config=transfer/transfer-06-consumer-pull-http/http-pull-consumer/consumer-configuration.properties -jar transfer/transfer-06-consumer-pull-http/http-pull-connector/build/libs/pull-connector.jar
 ```
 
 Assuming you didn't change the ports in config files, the consumer will listen on the

--- a/transfer/transfer-06-consumer-pull-http/http-pull-connector/build.gradle.kts
+++ b/transfer/transfer-06-consumer-pull-http/http-pull-connector/build.gradle.kts
@@ -51,7 +51,11 @@ application {
     mainClass.set("${edcGroupId}.boot.system.runtime.BaseRuntime")
 }
 
+var distTar = tasks.getByName("distTar")
+var distZip = tasks.getByName("distZip")
+
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("pull-connector.jar")
+    dependsOn(distTar, distZip)
 }

--- a/transfer/transfer-06-consumer-pull-http/http-pull-connector/build.gradle.kts
+++ b/transfer/transfer-06-consumer-pull-http/http-pull-connector/build.gradle.kts
@@ -53,5 +53,5 @@ application {
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
-    archiveFileName.set("http-pull-connector.jar")
+    archiveFileName.set("pull-connector.jar")
 }

--- a/transfer/transfer-07-provider-push-http/README.md
+++ b/transfer/transfer-07-provider-push-http/README.md
@@ -73,7 +73,7 @@ the configuration files.
 To run a provider, you should run the following command
 
 ```bash
-java -Dedc.keystore=transfer/transfer-07-provider-push-http/certs/cert.pfx -Dedc.keystore.password=123456 -Dedc.vault=transfer/transfer-07-provider-push-http/http-push-provider/provider-vault.properties -Dedc.fs.config=transfer/transfer-07-provider-push-http/http-push-provider/provider-configuration.properties -jar transfer/transfer-07-provider-push-http/http-push-connector/build/libs/http-push-connector.jar
+java -Dedc.keystore=transfer/transfer-07-provider-push-http/certs/cert.pfx -Dedc.keystore.password=123456 -Dedc.vault=transfer/transfer-07-provider-push-http/http-push-provider/provider-vault.properties -Dedc.fs.config=transfer/transfer-07-provider-push-http/http-push-provider/provider-configuration.properties -jar transfer/transfer-07-provider-push-http/http-push-connector/build/libs/push-connector.jar
 ```
 
 ### 2. Run a consumer
@@ -81,7 +81,7 @@ java -Dedc.keystore=transfer/transfer-07-provider-push-http/certs/cert.pfx -Dedc
 To run a consumer, you should run the following command
 
 ```bash
-java -Dedc.keystore=transfer/transfer-07-provider-push-http/certs/cert.pfx -Dedc.keystore.password=123456 -Dedc.vault=transfer/transfer-07-provider-push-http/http-push-consumer/consumer-vault.properties -Dedc.fs.config=transfer/transfer-07-provider-push-http/http-push-consumer/consumer-configuration.properties -jar transfer/transfer-07-provider-push-http/http-push-connector/build/libs/http-push-connector.jar
+java -Dedc.keystore=transfer/transfer-07-provider-push-http/certs/cert.pfx -Dedc.keystore.password=123456 -Dedc.vault=transfer/transfer-07-provider-push-http/http-push-consumer/consumer-vault.properties -Dedc.fs.config=transfer/transfer-07-provider-push-http/http-push-consumer/consumer-configuration.properties -jar transfer/transfer-07-provider-push-http/http-push-connector/build/libs/push-connector.jar
 ```
 
 Assuming you didn't change the ports in config files, the consumer will listen on the

--- a/transfer/transfer-07-provider-push-http/http-push-connector/build.gradle.kts
+++ b/transfer/transfer-07-provider-push-http/http-push-connector/build.gradle.kts
@@ -50,7 +50,11 @@ application {
     mainClass.set("${edcGroupId}.boot.system.runtime.BaseRuntime")
 }
 
+var distTar = tasks.getByName("distTar")
+var distZip = tasks.getByName("distZip")
+
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("push-connector.jar")
+    dependsOn(distTar, distZip)
 }

--- a/transfer/transfer-07-provider-push-http/http-push-connector/build.gradle.kts
+++ b/transfer/transfer-07-provider-push-http/http-push-connector/build.gradle.kts
@@ -52,5 +52,5 @@ application {
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
-    archiveFileName.set("http-push-connector.jar")
+    archiveFileName.set("push-connector.jar")
 }


### PR DESCRIPTION
## What this PR changes/adds

Add libs.versions.toml file to declare dependencies.
Update gradle version
Rename .jar for samples - transfer-06-consumer-pull-http, transfer-07-provider-push-http

## Why it does that
Renaming of .jar for the above mentioned samples were done to resolve the issue: problems found with the configuration of task shadowJar

## Further notes


## Linked Issue(s)

## Checklist

- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] documented code?
- [ ] assigned appropriate label?
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Samples/blob/main/CONTRIBUTING.md#submit-a-pull-request) for details_)