### PR TITLE
build(deps): bump gradle-wrapper to 7.6.1

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -28,6 +28,16 @@ jobs:
       - name: Run Checkstyle
         run: ./gradlew checkstyleMain checkstyleTest checkstyleTestFixtures
 
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-build
+
+      - name: Build project
+        run: ./gradlew build
+
+
   Sanity-Check:
     runs-on: ubuntu-latest
     steps:
@@ -43,7 +53,6 @@ jobs:
           grep "INFO.*edc-.*ready" log.txt
           rm log.txt
           killall java
-
 
       - name: Check Sample basic-02
         run: |
@@ -117,13 +126,6 @@ jobs:
         uses: ./.github/actions/run-tests
         with:
           command: ./gradlew test -DincludeTags="EndToEndTest"
-
-      - name: "Publish Gatling report"
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: Gatling reports
-          path: '**/build/reports/gatling/**'
 
   Upload-Test-Report:
     needs:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## What this PR changes/adds

Bump gradle-wrapper to 7.6.1

## Why it does that

Avoid conflicts with jackson 2.15.0

## Further notes

- add a "build" CI job to test out the whole project build status
- removed an useless gatling upload job

## Linked Issue(s)

Closes #45 
Closes #48 