### PR TITLE
Fixed a config error where the "old" metamodel was not found by gradle

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ javaVersion=11
 # configure the build:
 annotationProcessorVersion=0.0.1-SNAPSHOT
 edcGradlePluginsVersion=0.0.1-SNAPSHOT
-metaModelVersion=0.0.1-SNAPSHOT
+metaModelVersion=0.0.1-milestone-8


### PR DESCRIPTION
## What this PR changes/adds

Changed the `metaModelVersion` attribute in the `gradle.properties` from the default value `0.0.1-SNAPSHOT` to `0.0.1-milestone-8`. 

## Why it does that
Because of the introduction of milestone-9 artifacts, the old way of addressing the metamodel with the Snapshot version, seems to be no longer a valid option.

## Further notes
Probably the other config values also need a change. Currently, I just encountered a direct error with this config parameter, and I am not sure what the others are doing.

## Linked Issue(s)

Closes #56 
