### PR TITLE
fix: set explicit context for ODRL

### DIFF
--- a/transfer/transfer-01-file-transfer/contractoffer.json
+++ b/transfer/transfer-01-file-transfer/contractoffer.json
@@ -1,6 +1,7 @@
 {
   "@context": {
-    "edc": "https://w3id.org/edc/v0.0.1/ns/"
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "odrl": "http://www.w3.org/ns/odrl/2/"
   },
   "@type": "NegotiationInitiateRequestDto",
   "connectorId": "provider",
@@ -12,13 +13,12 @@
     "offerId": "1:test-document:3a75736e-001d-4364-8bd4-9888490edb58",
     "assetId": "test-document",
     "policy": {
-      "@context": "http://www.w3.org/ns/odrl.jsonld",
       "@id": "1:test-document:13dce0f1-52ed-4554-a194-e83e92733ee5",
       "@type": "set",
-      "permission": [],
-      "prohibition": [],
-      "obligation": [],
-      "target": "test-document"
+      "odrl:permission": [],
+      "odrl:prohibition": [],
+      "odrl:obligation": [],
+      "odrl:target": "test-document"
     }
   }
 }

--- a/transfer/transfer-01-file-transfer/filetransfer.json
+++ b/transfer/transfer-01-file-transfer/filetransfer.json
@@ -4,12 +4,9 @@
   },
   "@type": "TransferRequestDto",
   "dataDestination": {
-    "@type": "DataAddress",
     "type": "File",
-    "properties": {
-      "path": "{path to destination file}",
-      "keyName": "keyName"
-    }
+    "path": "{path to destination file}",
+    "keyName": "keyName"
   },
   "protocol": "dataspace-protocol-http",
   "assetId": "test-document",

--- a/transfer/transfer-04-open-telemetry/filetransfer.json
+++ b/transfer/transfer-04-open-telemetry/filetransfer.json
@@ -3,11 +3,9 @@
   "assetId": "test-document",
   "contractId": "{agreement ID}",
   "dataDestination": {
-    "properties": {
-      "path": "/samples/output-file.txt",
-      "keyName": "keyName",
-      "type": "File"
-    }
+    "path": "/samples/output-file.txt",
+    "keyName": "keyName",
+    "type": "File"
   },
   "transferType": {
     "contentType": "application/octet-stream",

--- a/transfer/transfer-05-file-transfer-cloud/README.md
+++ b/transfer/transfer-05-file-transfer-cloud/README.md
@@ -158,12 +158,9 @@ curl --location --request POST 'http://localhost:9192/management/transferprocess
   "assetId": "1",
   "contractId": "<ContractAgreementId>",
   "dataDestination": {
-    "properties": {
-      "type": "AmazonS3",
-      "region": "us-east-1",
-      "bucketName": "<Unique bucket name>"
-    },
-    "type": "AmazonS3"
+    "type": "AmazonS3",
+    "region": "us-east-1",
+    "bucketName": "<Unique bucket name>"
   },
   "managedResources": true,
   "transferType": {

--- a/transfer/transfer-06-consumer-pull-http/README.md
+++ b/transfer/transfer-06-consumer-pull-http/README.md
@@ -181,11 +181,9 @@ curl -d '{
              }
            },
            "dataAddress": {
-             "properties": {
-               "name": "Test asset",
-               "baseUrl": "https://jsonplaceholder.typicode.com/users",
-               "type": "HttpData"
-             }
+             "type": "HttpData",
+             "name": "Test asset",
+             "baseUrl": "https://jsonplaceholder.typicode.com/users"
            }
          }' -H 'content-type: application/json' http://localhost:19193/management/v2/assets \
          -s | jq
@@ -205,15 +203,15 @@ This means that the consumer connector can request any asset from the provider c
 ```bash
 curl -d '{
            "@context": {
-             "edc": "https://w3id.org/edc/v0.0.1/ns/"
+             "edc": "https://w3id.org/edc/v0.0.1/ns/",
+             "odrl": "http://www.w3.org/ns/odrl/2/"
            },
            "@id": "aPolicy",
            "policy": {
-             "@context": "http://www.w3.org/ns/odrl.jsonld",
              "@type": "set",
-             "permission": [],
-             "prohibition": [],
-             "obligation": []
+             "odrl:permission": [],
+             "odrl:prohibition": [],
+             "odrl:obligation": []
            }
          }' -H 'content-type: application/json' http://localhost:19193/management/v2/policydefinitions \
          -s | jq
@@ -344,7 +342,8 @@ send counter offers in addition to just confirming or declining an offer.
 ```bash
 curl -d '{
   "@context": {
-    "edc": "https://w3id.org/edc/v0.0.1/ns/"
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "odrl": "http://www.w3.org/ns/odrl/2/"
   },
   "@type": "NegotiationInitiateRequestDto",
   "connectorId": "provider",
@@ -356,13 +355,12 @@ curl -d '{
    "offerId": "1:assetId:902a192a-dcc6-49d0-8c9f-17daa9303730",
    "assetId": "assetId",
    "policy": {
-     "@context": "http://www.w3.org/ns/odrl.jsonld",
      "@id": "1:assetId:902a192a-dcc6-49d0-8c9f-17daa9303730",
      "@type": "Set",
-     "permission": [],
-     "prohibition": [],
-     "obligation": [],
-     "target": "assetId"
+     "odrl:permission": [],
+     "odrl:prohibition": [],
+     "odrl:obligation": [],
+     "odrl:target": "assetId"
    }
   }
 }' -X POST -H 'content-type: application/json' http://localhost:29193/management/v2/contractnegotiations \
@@ -450,7 +448,6 @@ curl -X POST "http://localhost:29193/management/v2/transferprocesses" \
         "managedResources": false,
         "protocol": "dataspace-protocol-http",
         "dataDestination": { 
-          "@type": "DataAddress",
           "type": "HttpProxy" 
         }
     }' \

--- a/transfer/transfer-07-provider-push-http/README.md
+++ b/transfer/transfer-07-provider-push-http/README.md
@@ -143,11 +143,9 @@ curl -d '{
              }
            },
            "dataAddress": {
-             "properties": {
-               "name": "Test asset",
-               "baseUrl": "https://jsonplaceholder.typicode.com/users",
-               "type": "HttpData"
-             }
+             "name": "Test asset",
+             "baseUrl": "https://jsonplaceholder.typicode.com/users",
+             "type": "HttpData"
            }
          }' -H 'content-type: application/json' http://localhost:19193/management/v2/assets \
          -s | jq
@@ -167,15 +165,15 @@ This means that the consumer connector can request any asset from the provider c
 ```bash
 curl -d '{
            "@context": {
-             "edc": "https://w3id.org/edc/v0.0.1/ns/"
+             "edc": "https://w3id.org/edc/v0.0.1/ns/",
+             "odrl": "http://www.w3.org/ns/odrl/2/"
            },
            "@id": "aPolicy",
            "policy": {
-             "@context": "http://www.w3.org/ns/odrl.jsonld",
              "@type": "set",
-             "permission": [],
-             "prohibition": [],
-             "obligation": []
+             "odrl:permission": [],
+             "odrl:prohibition": [],
+             "odrl:obligation": []
            }
          }' -H 'content-type: application/json' http://localhost:19193/management/v2/policydefinitions \
          -s | jq
@@ -304,7 +302,8 @@ send counter offers in addition to just confirming or declining an offer.
 ```bash
 curl -d '{
   "@context": {
-    "edc": "https://w3id.org/edc/v0.0.1/ns/"
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "odrl": "http://www.w3.org/ns/odrl/2/"
   },
   "@type": "NegotiationInitiateRequestDto",
   "connectorId": "provider",
@@ -316,13 +315,12 @@ curl -d '{
    "offerId": "1:assetId:902a192a-dcc6-49d0-8c9f-17daa9303730",
    "assetId": "assetId",
    "policy": {
-     "@context": "http://www.w3.org/ns/odrl.jsonld",
      "@id": "1:assetId:902a192a-dcc6-49d0-8c9f-17daa9303730",
      "@type": "Set",
-     "permission": [],
-     "prohibition": [],
-     "obligation": [],
-     "target": "assetId"
+     "odrl:permission": [],
+     "odrl:prohibition": [],
+     "odrl:obligation": [],
+     "odrl:target": "assetId"
    }
   }
 }' -X POST -H 'content-type: application/json' http://localhost:29193/management/v2/contractnegotiations \
@@ -409,11 +407,8 @@ curl -X POST "http://localhost:29193/management/v2/transferprocesses" \
         "managedResources": false,
         "protocol": "dataspace-protocol-http",
         "dataDestination": { 
-          "@type": "DataAddress",
           "type": "HttpData",
-          "properties": {
-            "baseUrl": "http://localhost:4000/api/consumer/store"
-          }
+          "baseUrl": "http://localhost:4000/api/consumer/store"
         }
     }' \
     -s | jq


### PR DESCRIPTION
## What this PR changes/adds

Set the explicit context for ODRL to avoid http calls for a remote context

## Why it does that

fiix samples

## Further notes

- "inlined" the `properties` field of `dataAddress`, because it will disappear with the new EDC version.

## Linked Issue(s)

Closes #63
Closes #64
Closes #67