### PR TITLE
fix: adapt paths to v2

### DIFF
--- a/system-tests/src/test/java/org/eclipse/edc/samples/transfer/FileTransferSampleTestCommon.java
+++ b/system-tests/src/test/java/org/eclipse/edc/samples/transfer/FileTransferSampleTestCommon.java
@@ -116,7 +116,7 @@ public class FileTransferSampleTestCommon {
 
     /**
      * Assert that a POST request to initiate a contract negotiation is successful.
-     * This method corresponds to the command in the sample: {@code curl -X POST -H "Content-Type: application/json" -H "X-Api-Key: password" -d @transfer/transfer-01-file-transfer/contractoffer.json "http://localhost:9192/management/contractnegotiations"}
+     * This method corresponds to the command in the sample: {@code curl -X POST -H "Content-Type: application/json" -H "X-Api-Key: password" -d @transfer/transfer-01-file-transfer/contractoffer.json "http://localhost:9192/management/v2/contractnegotiations"}
      */
     void initiateContractNegotiation() {
         contractNegotiationId = given()
@@ -145,7 +145,7 @@ public class FileTransferSampleTestCommon {
 
     /**
      * Assert that a GET request to look up a contract agreement is successful.
-     * This method corresponds to the command in the sample: {@code curl -X GET -H 'X-Api-Key: password' "http://localhost:9192/management/contractnegotiations/{UUID}"}
+     * This method corresponds to the command in the sample: {@code curl -X GET -H 'X-Api-Key: password' "http://localhost:9192/management/v2/contractnegotiations/{UUID}"}
      */
     void lookUpContractAgreementId() {
         // Wait for transfer to be completed.
@@ -163,7 +163,7 @@ public class FileTransferSampleTestCommon {
 
     /**
      * Assert that a POST request to initiate transfer process is successful.
-     * This method corresponds to the command in the sample: {@code curl -X POST -H "Content-Type: application/json" -H "X-Api-Key: password" -d @transfer/transfer-01-file-transfer/filetransfer.json "http://localhost:9192/management/transferprocess"}
+     * This method corresponds to the command in the sample: {@code curl -X POST -H "Content-Type: application/json" -H "X-Api-Key: password" -d @transfer/transfer-01-file-transfer/filetransfer.json "http://localhost:9192/management/v2/transferprocesses"}
      *
      * @throws IOException Thrown if there was an error accessing the transfer request file defined in {@link FileTransferSampleTestCommon#TRANSFER_FILE_PATH}.
      */

--- a/transfer/transfer-02-file-transfer-listener/README.md
+++ b/transfer/transfer-02-file-transfer-listener/README.md
@@ -59,9 +59,9 @@ Open another terminal window (or any REST client of your choice) and execute the
 previous sample:
 
 ```bash
-curl -X POST -H "Content-Type: application/json" -H "X-Api-Key: password" -d @transfer/transfer-01-file-transfer/contractoffer.json "http://localhost:9192/management/contractnegotiations"
-curl -X GET -H 'X-Api-Key: password' "http://localhost:9192/management/contractnegotiations/{UUID}"
-curl -X POST -H "Content-Type: application/json" -H "X-Api-Key: password" -d @transfer/transfer-01-file-transfer/filetransfer.json "http://localhost:9192/management/transferprocess"
+curl -X POST -H "Content-Type: application/json" -H "X-Api-Key: password" -d @transfer/transfer-01-file-transfer/contractoffer.json "http://localhost:9192/management/v2/contractnegotiations"
+curl -X GET -H 'X-Api-Key: password' "http://localhost:9192/management/v2/contractnegotiations/{UUID}"
+curl -X POST -H "Content-Type: application/json" -H "X-Api-Key: password" -d @transfer/transfer-01-file-transfer/filetransfer.json "http://localhost:9192/management/v2/transferprocesses"
 ```
 
 > **Replace `{UUID}` in the second request with the UUID received as the response to the first request!**

--- a/transfer/transfer-04-open-telemetry/README.md
+++ b/transfer/transfer-04-open-telemetry/README.md
@@ -39,7 +39,7 @@ docker-compose -f transfer/transfer-04-open-telemetry/docker-compose.yaml up --a
 Once the consumer and provider are up, start a contract negotiation by executing:
 
 ```bash
-curl -X POST -H "Content-Type: application/json" -H "X-Api-Key: password" -d @transfer/transfer-04-open-telemetry/contractoffer.json "http://localhost:9192/management/contractnegotiations"
+curl -X POST -H "Content-Type: application/json" -H "X-Api-Key: password" -d @transfer/transfer-04-open-telemetry/contractoffer.json "http://localhost:9192/management/v2/contractnegotiations"
 ```
 
 The contract negotiation causes an HTTP request sent from the consumer to the provider connector, followed by another
@@ -47,13 +47,13 @@ message from the provider to the consumer connector. Query the status of the con
 following command. Wait until the negotiation is in CONFIRMED state and note down the contract agreement id.
 
 ```bash
-curl -X GET -H 'X-Api-Key: password' "http://localhost:9192/management/contractnegotiations/{UUID}"
+curl -X GET -H 'X-Api-Key: password' "http://localhost:9192/management/v2/contractnegotiations/{UUID}"
 ```
 
 Finally, update the contract agreement id in the `filetransfer.json` file and execute a file transfer with the following command:
 
 ```bash
-curl -X POST -H "Content-Type: application/json" -H "X-Api-Key: password" -d @transfer/transfer-04-open-telemetry/filetransfer.json "http://localhost:9192/management/transferprocess"
+curl -X POST -H "Content-Type: application/json" -H "X-Api-Key: password" -d @transfer/transfer-04-open-telemetry/filetransfer.json "http://localhost:9192/management/v2/transferprocesses"
 ```
 
 You can access the Jaeger UI on your browser at `http://localhost:16686`. In the search tool, we can select the service

--- a/transfer/transfer-05-file-transfer-cloud/README.md
+++ b/transfer/transfer-05-file-transfer-cloud/README.md
@@ -113,7 +113,7 @@ To negotiate a contract copy one of the contract offers into the statement below
 it is only possible to negotiate an _unchanged_ contract, so counter offers are not supported.
 
 ```bash
-curl --location --request POST 'http://localhost:9192/management/contractnegotiations' \
+curl --location --request POST 'http://localhost:9192/management/v2/contractnegotiations' \
 --header 'X-API-Key: password' \
 --header 'Content-Type: application/json' \
 --data-raw '{
@@ -135,7 +135,7 @@ The EDC will answer with the contract negotiation id. This id will be used in st
 To get the contract agreement id insert the negotiation id into the following statement end execute it.
 
 ```bash
-curl -X GET -H 'X-Api-Key: password' "http://localhost:9192/management/contractnegotiations/{negotiationId}"
+curl -X GET -H 'X-Api-Key: password' "http://localhost:9192/management/v2/contractnegotiations/{negotiationId}"
 ```
 
 The EDC will return the current state of the contract negotiation. When the negotiation is completed successfully
@@ -147,7 +147,7 @@ To initiate the data transfer, execute the statement below. Please take care of 
 obtained at previous step as well as a unique bucket name.
 
 ```bash
-curl --location --request POST 'http://localhost:9192/management/transferprocess' \
+curl --location --request POST 'http://localhost:9192/management/v2/transferprocesses' \
 --header 'X-API-Key: password' \
 --header 'Content-Type: application/json' \
 --data-raw '
@@ -178,7 +178,7 @@ Deprovisioning is not necessary per se, but it will do some cleanup, delete the 
 it's generally advisable to do it.
 
 ```bash
-curl -X POST -H 'X-Api-Key: password' "http://localhost:9192/management/transferprocess/{transferProcessId}/deprovision"
+curl -X POST -H 'X-Api-Key: password' "http://localhost:9192/management/v2/transferprocesses/{transferProcessId}/deprovision"
 ```
 
 Finally, run terraform to clean-up the vault and other remaining stuffs:


### PR DESCRIPTION
## What this PR changes/adds

Update paths to v2 that stayed behind during the update to v 0.1.0

## Why it does that

fix samples

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #68
Closes #69

## Checklist

- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] documented code?
- [ ] assigned appropriate label?
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Samples/blob/main/CONTRIBUTING.md#submit-a-pull-request) for details_)