### PR TITLE
docs: fixed curl command in provider push README

### DIFF
--- a/transfer/transfer-07-provider-push-http/README.md
+++ b/transfer/transfer-07-provider-push-http/README.md
@@ -116,10 +116,9 @@ curl -H 'Content-Type: application/json' \
            "allowedSourceTypes": [ "HttpData" ],
            "allowedDestTypes": [ "HttpProxy", "HttpData" ],
            "properties": {
-                "https://w3id.org/edc/v0.0.1/ns/publicApiUrl": "http://localhost:19291/public/",
+                "https://w3id.org/edc/v0.0.1/ns/publicApiUrl": "http://localhost:19291/public/"
             }
-         }
- }' \
+         }' \
      -X POST "http://localhost:19193/management/v2/dataplanes"
 ```
 


### PR DESCRIPTION
## What this PR changes/adds

documentation had some invalid JSON body for the register data plane command in `transfer-07-provider-push-http`, fixed it here

## Linked Issue(s)

Closes #94 

## Checklist

- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] documented code?
- [ ] assigned appropriate label?
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Samples/blob/main/CONTRIBUTING.md#submit-a-pull-request) for details_)