### PR TITLE
refactor: centralize EDC version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,14 +21,13 @@ repositories {
     mavenCentral()
 }
 
-val edcVersion: String by project
-
 buildscript {
     dependencies {
-        val edcVersion: String by project
-        classpath("org.eclipse.edc.edc-build:org.eclipse.edc.edc-build.gradle.plugin:${edcVersion}")
+        classpath(libs.edc.build.plugin)
     }
 }
+
+val edcVersion = libs.versions.edc
 
 allprojects {
     apply(plugin = "$group.edc-build")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,1 @@
 group=org.eclipse.edc
-edcVersion=0.1.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ edc-api-core = { module = "org.eclipse.edc:api-core", version.ref = "edc" }
 edc-api-observability = { module = "org.eclipse.edc:api-observability", version.ref = "edc" }
 edc-auth-tokenbased = { module = "org.eclipse.edc:auth-tokenbased", version.ref = "edc" }
 edc-boot = { module = "org.eclipse.edc:boot", version.ref = "edc" }
+edc-build-plugin = { module = "org.eclipse.edc.edc-build:org.eclipse.edc.edc-build.gradle.plugin", version.ref = "edc" }
 edc-configuration-filesystem = { module = "org.eclipse.edc:configuration-filesystem", version.ref = "edc" }
 edc-connector-core = { module = "org.eclipse.edc:connector-core", version.ref = "edc" }
 edc-control-plane-core = { module = "org.eclipse.edc:control-plane-core", version.ref = "edc" }


### PR DESCRIPTION
## What this PR changes/adds

Centralizes EDC version number.

## Why it does that

refactoring

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #109 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
