### PR TITLE
docs: IDS cleanup and replace with DSP

### DIFF
--- a/basic/basic-03-configuration/README.md
+++ b/basic/basic-03-configuration/README.md
@@ -171,7 +171,7 @@ web.http.management.path=/management
 ```
 
 _**Caution**: If you do not provide this configuration, it leads to the problem that the authentication mechanism is
-also applied to EVERY request in the _default_ context of Jetty, which includes the IDS communication between two
+also applied to EVERY request in the _default_ context of Jetty, which includes the DSP communication between two
 connectors._
 
 ---

--- a/transfer/transfer-01-file-transfer/README.md
+++ b/transfer/transfer-01-file-transfer/README.md
@@ -9,7 +9,7 @@ more sophisticated storage locations, like a database or a cloud storage.
 This is quite a big step up from the previous sample, where we ran only one connector. Those are the concrete tasks:
 
 * Creating an additional connector, so that in the end we have two connectors, a consumer and a provider
-* Providing communication between provider and consumer using IDS multipart messages
+* Providing communication between provider and consumer using DSP multipart messages
 * Utilizing the management API to interact with the connector system
 * Performing a contract negotiation between provider and consumer
 * Performing a file transfer
@@ -120,7 +120,7 @@ implementation(libs.edc.auth.tokenbased)
 ```
 
 Three of these dependencies are new and have not been used in the previous samples:
-1. `data-protocols:ids`: contains all IDS modules and therefore enables IDS Multipart communication with other connectors
+1. `data-protocols:dsp`: contains all DSP modules and therefore enables DSP Multipart communication with other connectors
 2. `extensions:iam:iam-mock`: provides a no-op identity provider, which does not require certificates and performs no checks
 3. `extensions:api:auth-tokenbased`: adds authentication for management API endpoints
 
@@ -136,7 +136,7 @@ implementation(project(":transfer:transfer-01-file-transfer:transfer-file-local"
 We also need to adjust the provider's `config.properties`. The property `edc.samples.transfer.01.asset.path` should
 point to an existing file in our local environment, as this is the file that will be transferred. We also configure a
 separate API context for the management API, like we learned in previous chapter. Then we add the property
-`edc.dsp.callback.address`, which should point to our provider connector's IDS address. This is used as the callback
+`edc.dsp.callback.address`, which should point to our provider connector's DSP address. This is used as the callback
 address during the contract negotiation. Since the DSP API is running on a different port (default is `8282`), we set
 the webhook address to `http://localhost:8282/protocol` accordingly.
 
@@ -149,8 +149,8 @@ We configure the consumer's API ports in `consumer/config.properties`, so that i
 provider. In the config file, we also need to configure the API key authentication, as we're going to use
 endpoints from the EDC's management API in this sample and integrated the extension for token-based API
 authentication. Therefore, we add the property `edc.api.auth.key` and set it to e.g. `password`. And last, we also need
-to configure the consumer's webhook address. We expose the IDS API endpoints on a different port and path than other
-endpoints, so the property `edc.dsp.callback.address` is adjusted to match the IDS API port.
+to configure the consumer's webhook address. We expose the DSP API endpoints on a different port and path than other
+endpoints, so the property `edc.dsp.callback.address` is adjusted to match the DSP API port.
 
 The consumer connector also needs the `status-checker` extension for marking the transfer as completed on the consumer
 side.

--- a/transfer/transfer-01-file-transfer/README.md
+++ b/transfer/transfer-01-file-transfer/README.md
@@ -9,7 +9,7 @@ more sophisticated storage locations, like a database or a cloud storage.
 This is quite a big step up from the previous sample, where we ran only one connector. Those are the concrete tasks:
 
 * Creating an additional connector, so that in the end we have two connectors, a consumer and a provider
-* Providing communication between provider and consumer using DSP multipart messages
+* Providing communication between provider and consumer using DSP messages
 * Utilizing the management API to interact with the connector system
 * Performing a contract negotiation between provider and consumer
 * Performing a file transfer
@@ -120,7 +120,7 @@ implementation(libs.edc.auth.tokenbased)
 ```
 
 Three of these dependencies are new and have not been used in the previous samples:
-1. `data-protocols:dsp`: contains all DSP modules and therefore enables DSP Multipart communication with other connectors
+1. `data-protocols:dsp`: contains all DSP modules and therefore enables DSP communication with other connectors
 2. `extensions:iam:iam-mock`: provides a no-op identity provider, which does not require certificates and performs no checks
 3. `extensions:api:auth-tokenbased`: adds authentication for management API endpoints
 

--- a/transfer/transfer-04-open-telemetry/README.md
+++ b/transfer/transfer-04-open-telemetry/README.md
@@ -94,7 +94,7 @@ which has to be stored in the root folder of this sample as well. The only addit
       WEB_HTTP_PATH: /api
       WEB_HTTP_MANAGEMENT_PORT: 8182
       WEB_HTTP_MANAGEMENT_PATH: /management
-      IDS_WEBHOOK_ADDRESS: http://consumer:8181
+      DSP_WEBHOOK_ADDRESS: http://consumer:8181
     volumes:
       - ../:/samples
     ports:

--- a/transfer/transfer-04-open-telemetry/contractoffer.json
+++ b/transfer/transfer-04-open-telemetry/contractoffer.json
@@ -36,9 +36,9 @@
     },
     "asset": {
       "properties": {
-        "ids:byteSize": null,
+        "dsp:byteSize": null,
         "asset:prop:id": "test-document",
-        "ids:fileName": null
+        "dsp:fileName": null
       }
     }
   }

--- a/transfer/transfer-04-open-telemetry/contractoffer.json
+++ b/transfer/transfer-04-open-telemetry/contractoffer.json
@@ -36,9 +36,7 @@
     },
     "asset": {
       "properties": {
-        "dsp:byteSize": null,
-        "asset:prop:id": "test-document",
-        "dsp:fileName": null
+        "asset:prop:id": "test-document"
       }
     }
   }

--- a/transfer/transfer-04-open-telemetry/docker-compose.yaml
+++ b/transfer/transfer-04-open-telemetry/docker-compose.yaml
@@ -13,9 +13,9 @@ services:
       WEB_HTTP_PATH: /api
       WEB_HTTP_MANAGEMENT_PORT: 9192
       WEB_HTTP_MANAGEMENT_PATH: /management
-      WEB_HTTP_IDS_PORT: 9292
-      WEB_HTTP_IDS_PATH: /protocol
-      IDS_WEBHOOK_ADDRESS: http://consumer:9292
+      WEB_HTTP_DSP_PORT: 9292
+      WEB_HTTP_DSP_PATH: /protocol
+      DSP_WEBHOOK_ADDRESS: http://consumer:9292
       EDC_API_AUTH_KEY: password
     volumes:
       - ../:/samples
@@ -37,7 +37,7 @@ services:
       WEB_HTTP_PATH: /api
       WEB_HTTP_MANAGEMENT_PORT: 8182
       WEB_HTTP_MANAGEMENT_PATH: /management
-      IDS_WEBHOOK_ADDRESS: http://provider:8282
+      DSP_WEBHOOK_ADDRESS: http://provider:8282
       EDC_SAMPLES_TRANSFER_01_ASSET_PATH: /samples/transfer-04-open-telemetry/input-file.txt
     volumes:
       - ../:/samples

--- a/transfer/transfer-06-consumer-pull-http/README.md
+++ b/transfer/transfer-06-consumer-pull-http/README.md
@@ -102,8 +102,8 @@ java -Dedc.keystore=transfer/transfer-06-consumer-pull-http/certs/cert.pfx -Dedc
 ```
 
 Assuming you didn't change the ports in config files, the consumer will listen on the
-ports `29191`, `29192` (management API) and `29292` (IDS API) and the provider will listen on the
-ports `12181`, `19182` (management API) and `19282` (IDS API).
+ports `29191`, `29192` (management API) and `29292` (DSP API) and the provider will listen on the
+ports `12181`, `19182` (management API) and `19282` (DSP API).
 
 # Run the sample
 

--- a/transfer/transfer-06-consumer-pull-http/http-pull-consumer/consumer-configuration.properties
+++ b/transfer/transfer-06-consumer-pull-http/http-pull-consumer/consumer-configuration.properties
@@ -1,5 +1,5 @@
 edc.participant.id=consumer
-edc.ids.id=urn:connector:consumer
+edc.dsp.id=urn:connector:consumer
 edc.dsp.callback.address=http://localhost:29194/protocol
 web.http.port=29191
 web.http.path=/api

--- a/transfer/transfer-06-consumer-pull-http/http-pull-consumer/consumer-configuration.properties
+++ b/transfer/transfer-06-consumer-pull-http/http-pull-consumer/consumer-configuration.properties
@@ -1,5 +1,4 @@
 edc.participant.id=consumer
-edc.dsp.id=urn:connector:consumer
 edc.dsp.callback.address=http://localhost:29194/protocol
 web.http.port=29191
 web.http.path=/api

--- a/transfer/transfer-06-consumer-pull-http/http-pull-provider/provider-configuration.properties
+++ b/transfer/transfer-06-consumer-pull-http/http-pull-provider/provider-configuration.properties
@@ -1,5 +1,4 @@
 edc.participant.id=provider
-edc.dsp.id=urn:connector:provider
 edc.dsp.callback.address=http://localhost:19194/protocol
 web.http.port=19191
 web.http.path=/api

--- a/transfer/transfer-06-consumer-pull-http/http-pull-provider/provider-configuration.properties
+++ b/transfer/transfer-06-consumer-pull-http/http-pull-provider/provider-configuration.properties
@@ -1,5 +1,5 @@
 edc.participant.id=provider
-edc.ids.id=urn:connector:provider
+edc.dsp.id=urn:connector:provider
 edc.dsp.callback.address=http://localhost:19194/protocol
 web.http.port=19191
 web.http.path=/api

--- a/transfer/transfer-07-provider-push-http/README.md
+++ b/transfer/transfer-07-provider-push-http/README.md
@@ -83,8 +83,8 @@ java -Dedc.keystore=transfer/transfer-07-provider-push-http/certs/cert.pfx -Dedc
 ```
 
 Assuming you didn't change the ports in config files, the consumer will listen on the
-ports `29191`, `29193` (management API) and `29194` (IDS API) and the provider will listen on the
-ports `19191`, `19193` (management API) and `19194` (IDS API).
+ports `29191`, `29193` (management API) and `29194` (DSP API) and the provider will listen on the
+ports `19191`, `19193` (management API) and `19194` (DSP API).
 
 # Run the sample
 

--- a/transfer/transfer-07-provider-push-http/http-push-connector/build.gradle.kts
+++ b/transfer/transfer-07-provider-push-http/http-push-connector/build.gradle.kts
@@ -20,9 +20,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven {
-        url = uri("https://maven.iais.fraunhofer.de/artifactory/eis-ids-public/")
-    }
 }
 
 dependencies {

--- a/transfer/transfer-07-provider-push-http/http-push-consumer/consumer-configuration.properties
+++ b/transfer/transfer-07-provider-push-http/http-push-consumer/consumer-configuration.properties
@@ -1,4 +1,3 @@
-edc.dsp.id=urn:connector:consumer
 edc.participant.id=consumer
 edc.dsp.callback.address=http://localhost:29194/protocol
 web.http.port=29191

--- a/transfer/transfer-07-provider-push-http/http-push-consumer/consumer-configuration.properties
+++ b/transfer/transfer-07-provider-push-http/http-push-consumer/consumer-configuration.properties
@@ -1,4 +1,4 @@
-edc.ids.id=urn:connector:consumer
+edc.dsp.id=urn:connector:consumer
 edc.participant.id=consumer
 edc.dsp.callback.address=http://localhost:29194/protocol
 web.http.port=29191

--- a/transfer/transfer-07-provider-push-http/http-push-provider/provider-configuration.properties
+++ b/transfer/transfer-07-provider-push-http/http-push-provider/provider-configuration.properties
@@ -1,4 +1,3 @@
-edc.dsp.id=urn:connector:provider
 edc.participant.id=provider
 edc.dsp.callback.address=http://localhost:19194/protocol
 web.http.port=19191

--- a/transfer/transfer-07-provider-push-http/http-push-provider/provider-configuration.properties
+++ b/transfer/transfer-07-provider-push-http/http-push-provider/provider-configuration.properties
@@ -1,4 +1,4 @@
-edc.ids.id=urn:connector:provider
+edc.dsp.id=urn:connector:provider
 edc.participant.id=provider
 edc.dsp.callback.address=http://localhost:19194/protocol
 web.http.port=19191


### PR DESCRIPTION
## What this PR changes/adds

remove the leftovers of IDS dependencies and replace them with DSP . 
remove the IAIS dependency . 
## Why it does that

The IDS is no longer needed
## Further notes



## Linked Issue(s)

refers #103 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
