### PR TITLE
fix: add missing edc-control-plane-api-client dependency

### DIFF
--- a/transfer/transfer-06-consumer-pull-http/http-pull-connector/build.gradle.kts
+++ b/transfer/transfer-06-consumer-pull-http/http-pull-connector/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 }
 
 dependencies {
+    implementation(libs.edc.control.plane.api.client)
     implementation(libs.edc.control.plane.core)
     implementation(libs.edc.dsp)
     implementation(libs.edc.configuration.filesystem)


### PR DESCRIPTION
## What this PR changes/adds

Add edc-control-plane-api-client to resolve boot issue when running the jar for transfer-06-consumer-pull-http

## Why it does that

When running the jar following issues was coming:
org.eclipse.edc.spi.system.injection.EdcInjectionException: The following injected fields were not provided:
Field "transferProcessApiClient" of type [interface org.eclipse.edc.connector.api.client.spi.transferprocess.TransferProcessApiClient] required by org.eclipse.edc.connector.dataplane.framework.DataPlaneFrameworkExtension
To resolve it edc-control-plane-api-client is added as dependency


## Linked Issue(s)

Closes # <-- [_insert Issue number if one exists_](https://github.com/eclipse-edc/Connector/discussions/3436)


