### PR TITLE
fix(docs): change pipe to curl -s option

### DIFF
--- a/transfer/transfer-00-prerequisites/README.md
+++ b/transfer/transfer-00-prerequisites/README.md
@@ -88,7 +88,7 @@ Open a new terminal and execute:
 ```bash
 curl -H 'Content-Type: application/json' \
      -d @transfer/transfer-00-prerequisites/resources/dataplane/register-data-plane-provider.json \
-     -X POST "http://localhost:19193/management/v2/dataplanes" | -s | jq
+     -X POST "http://localhost:19193/management/v2/dataplanes" -s | jq
 ```
 
 The connectors have been configured successfully and are ready to be used.


### PR DESCRIPTION
## What this PR changes/adds

It removes a pipe operator

## Why it does that

Because otherwise the `-s` option for curl is understood as a command line command. Simply copy pasting the example code results in an error in the command line

