### PR TITLE
docs: fix invalid command line in the README of transfer-00-prerequisites

### DIFF
--- a/transfer/transfer-00-prerequisites/README.md
+++ b/transfer/transfer-00-prerequisites/README.md
@@ -88,7 +88,7 @@ Open a new terminal and execute:
 ```bash
 curl -H 'Content-Type: application/json' \
      -d @transfer/transfer-00-prerequisites/resources/dataplane/register-data-plane-provider.json \
-     -X POST "http://localhost:19193/management/v2/dataplanes" | -s | jq
+     -X POST "http://localhost:19193/management/v2/dataplanes" -s | jq
 ```
 
 The connectors have been configured successfully and are ready to be used.


### PR DESCRIPTION
## What this PR changes/adds

fix the invalid command line of [README of transfer-00-prerequisites](https://github.com/eclipse-edc/Samples/tree/e9e41d5bdd56a2411fa2d462189faa0480ffe811/transfer/transfer-00-prerequisites#3-register-data-plane-instance-for-provider).

## Why it does that

extra `|` before `-s` causes error on copying from browser and pasting.

```
$ curl -H 'Content-Type: application/json' \
     -d @transfer/transfer-00-prerequisites/resources/dataplane/register-data-plane-provider.json \
     -X POST "http://localhost:19193/management/v2/dataplanes" | -s | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (7) Failed to connect to localhost port 19193 after 0 ms: Connection refused
-s: command not found
```

## Linked Issue(s)

Closes #148

