### PR TITLE
fix: HttpRequestLoggerServer should not keep the connection open

### DIFF
--- a/util/http-request-logger/src/main/java/org/eclipse/edc/samples/util/HttpRequestLoggerServer.java
+++ b/util/http-request-logger/src/main/java/org/eclipse/edc/samples/util/HttpRequestLoggerServer.java
@@ -49,7 +49,7 @@ public class HttpRequestLoggerServer {
             System.out.println("Body:");
             System.out.println(new String(exchange.getRequestBody().readAllBytes()));
             System.out.println("=============");
-            exchange.sendResponseHeaders(200, 0);
+            exchange.sendResponseHeaders(200, -1);
         }
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Make HttpRequestLoggerServer return `Content-length: 0` instead of `Transfer-encoding: chunked`.

```
$ curl -i -X POST --data baz localhost:4000/foo/bar
HTTP/1.1 200 OK
Date: Mon, 20 Nov 2023 08:08:10 GMT
Transfer-encoding: chunked

(curl keeps waiting for response body from server)
```

after:

```
$ curl -i -X POST --data baz localhost:4000/foo/bar
HTTP/1.1 200 OK
Date: Mon, 20 Nov 2023 09:38:23 GMT
Content-length: 0

```


## Why it does that

Setting 0 to `responseLength` of [HttpExchange#sendResponseHeaders](https://github.com/openjdk/jdk17u/blob/df82c1c6490bb5114fe52e4e1a4faa6aa3a56cfd/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java#L178-L214) means chunked transfer for sending response. Clients wait for the response body until the stream os response body is closed in the server.



## Linked Issue(s)

Closes #157

