### PR TITLE
Update README.md

### DIFF
--- a/transfer/transfer-01-negotiation/README.md
+++ b/transfer/transfer-01-negotiation/README.md
@@ -43,7 +43,7 @@ The following [request](resources/create-asset.json) creates an asset on the pro
 
 ```bash
 curl -d @transfer/transfer-01-negotiation/resources/create-asset.json \
-  -H 'content-type: application/json' http://localhost:19193/management/v2/assets \
+  -H 'content-type: application/json' http://localhost:19193/management/v3/assets \
   -s | jq
 ```
 


### PR DESCRIPTION
The URL of **1. Create an Asset on the provider side** is wrong. Currently used edc version: 0.4.1
## What this PR changes/adds

update the URL of [1. Create an Asset on the provider side](https://github.com/eclipse-edc/Samples/tree/main/transfer/transfer-01-negotiation#1-create-an-asset-on-the-provider-side) from `http://localhost:19193/management/v2/assets` to `http://localhost:19193/management/v3/assets`

## Why it does that
If we use the **/v2/assets**, the response is 404.

## Another Issue
The request body of **5. Negotiate a contract** is wrong. When we send the request with body [negotiate-contract.json](https://github.com/eclipse-edc/Samples/blob/main/transfer/transfer-01-negotiation/resources/negotiate-contract.json), get the response 400 Bad Request. Please update the request body according to the [ContractNegotiationApi.java](https://github.com/eclipse-edc/Connector/blob/cd0f8eb2c20f61b8e4d7562b0926ce48797c4aeb/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApi.java#L45)