### PR TITLE
build: Dependency Correction on Cloud Transfer Sample

### DIFF
--- a/transfer/transfer-05-file-transfer-cloud/cloud-transfer-consumer/build.gradle.kts
+++ b/transfer/transfer-05-file-transfer-cloud/cloud-transfer-consumer/build.gradle.kts
@@ -34,6 +34,8 @@ dependencies {
     implementation(libs.edc.management.api)
 
     implementation(libs.edc.dsp)
+    
+    implementation(libs.edc.data.plane.selector.core)
 }
 
 application {

--- a/transfer/transfer-05-file-transfer-cloud/transfer-file-cloud/build.gradle.kts
+++ b/transfer/transfer-05-file-transfer-cloud/transfer-file-cloud/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
 
 dependencies {
     implementation(libs.edc.control.plane.core)
+    implementation(libs.edc.control.plane.api.client)
     implementation(libs.edc.data.plane.core)
     implementation(libs.edc.data.plane.azure.storage)
     implementation(libs.edc.data.plane.aws.s3)


### PR DESCRIPTION
## What this PR changes/adds

This PR adds dependencies on the "transfer/transfer-05-file-transfer-cloud/cloud-transfer-consumer/build.gradle.kts" and "transfer/transfer-05-file-transfer-cloud/transfer-file-cloud/build.gradle.kts"

## Why it does that

This dependencies are added because there was an error when trying to run the jar file.

[Linked Discussion](https://github.com/eclipse-edc/Samples/discussions/174)
