### PR TITLE
fix: add context to policy in the creation request

### DIFF
--- a/transfer/transfer-01-negotiation/resources/create-policy.json
+++ b/transfer/transfer-01-negotiation/resources/create-policy.json
@@ -1,11 +1,11 @@
 {
   "@context": {
     "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
-    "odrl": "http://www.w3.org/ns/odrl/2/"
   },
   "@id": "aPolicy",
   "policy": {
-    "@type": "set",
+    "@context": "http://www.w3.org/ns/odrl.jsonld",
+    "@type": "Set",
     "odrl:permission": [],
     "odrl:prohibition": [],
     "odrl:obligation": []


### PR DESCRIPTION
## What this PR changes/adds

Add the context to the policy in the creation request.

## Why it does that

The context is necessary to have the policy type properly parsed.
