### PR TITLE
docs: updated README.md for transfer-02-consumer-pull

### DIFF
--- a/transfer/transfer-02-consumer-pull/README.md
+++ b/transfer/transfer-02-consumer-pull/README.md
@@ -99,7 +99,7 @@ to get the data from the provider:
 ```json
 {
   "id": "591bb609-1edb-4a6b-babe-50f1eca3e1e9",
-  "endpoint": "http://localhost:29291/public/",
+  "endpoint": "http://localhost:19291/public/",
   "authKey": "Authorization",
   "authCode": "{{auth-code}}",
   "properties": {
@@ -112,7 +112,7 @@ Once this json is read, use a tool like postman or curl to execute the following
 data
 
 ```bash
-curl --location --request GET 'http://localhost:29291/public/' --header 'Authorization: <auth code>'
+curl --location --request GET 'http://localhost:19291/public/' --header 'Authorization: <auth code>'
 ```
 
 At the end, and to be sure that you correctly achieved the pull, you can check if the data you get
@@ -122,7 +122,7 @@ is the same as the one you can get at https://jsonplaceholder.typicode.com/users
 Since we configured the `HttpData` with `proxyPath`, we could also ask for a specific user with:
 
 ```bash
-curl --location --request GET 'http://localhost:29291/public/1' --header 'Authorization: <auth code>'
+curl --location --request GET 'http://localhost:19291/public/1' --header 'Authorization: <auth code>'
 ```
 
 And the data returned will be the same as in https://jsonplaceholder.typicode.com/users/1


### PR DESCRIPTION
## What this PR changes/adds

- changed the command for requesting data with the token to target the provider instead of the consumer

## Why it does that

The change reflects what already written in the README file as well as the [documentation in the Connector repo](https://github.com/eclipse-edc/Connector/blob/main/docs/developer/data-transfer.md#consumer-pull).

