### PR TITLE
fix: build.gradle.kts imports fixed

### DIFF
--- a/transfer/transfer-04-event-consumer/consumer-with-listener/build.gradle.kts
+++ b/transfer/transfer-04-event-consumer/consumer-with-listener/build.gradle.kts
@@ -21,8 +21,8 @@ plugins {
 dependencies {
 
     implementation(libs.edc.control.plane.api.client)
+    implementation(libs.edc.control.plane.api)
     implementation(libs.edc.control.plane.core)
-    implementation(libs.edc.control.plane.api.client)
     implementation(libs.edc.dsp)
     implementation(libs.edc.configuration.filesystem)
     implementation(libs.edc.vault.filesystem)


### PR DESCRIPTION
## What this PR changes/adds

"transfer/transfer-04-event-consumer/consumer-with-listener/build.gradle.kts" modified:

 "libs.edc.control.plane.api" added
 "libs.edc.control.plane.api" duplication eliminated

## Why it does that

We were running the guide examples and we wanted to reuse the connector.jar of "transfer-04-event-consumer" to all cases, but when we run the "Simple Provider push Http transfer flow" example we noticed that a 404 error appeared.

Comparing gradles we noticed that exists a duplicated and missing import in the 04 version. We copied the same imports from version 00 to 04 and all worked.



_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
