### PR TITLE
fix: update description about required Java version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ strongly advise reading the [documentation](https://eclipse-edc.github.io/docs/#
 
 Also, a working knowledge of **Git**, **Gradle**, **Java** and **HTTP** is presumed.
 
-We'll assume that you've just checked out the samples code base and have **Java 11+** installed on your development
-machine. If not, please download and install JDK 11+ for your OS.
+We'll assume that you've just checked out the samples code base and have **Java 17+** installed on your development
+machine. If not, please download and install JDK 17+ for your OS.
 
 Command examples in this document will use the `bash` syntax and use Unix-style paths, but any other shell should be
 fine as well. If you're using Windows you either need to adapt the paths or use WSL2.

--- a/advanced/advanced-01-open-telemetry/README.md
+++ b/advanced/advanced-01-open-telemetry/README.md
@@ -232,11 +232,11 @@ In order to provide your own OpenTelemetry implementation, you have to "deploy a
 - Add a file in the resource directory META-INF/services. The file should be called `io.opentelemetry.api.OpenTelemetry`.
 - Add to the file the fully qualified name of your custom OpenTelemetry implementation class.
 
-EDC uses a [ServiceLoader](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html)
+EDC uses a [ServiceLoader](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/ServiceLoader.html)
 to load an implementation of OpenTelemetry. If it finds an OpenTelemetry service provider on the class path it will use
 it, otherwise it will use the registered global OpenTelemetry. You can look at the section
 `Deploying service providers on the class path` of the
-[ServiceLoader documentation](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html)
+[ServiceLoader documentation](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/ServiceLoader.html)
 to have more information about service providers.
 
 ---


### PR DESCRIPTION
## What this PR changes/adds

updated description about required Java version in the README.

## Why it does that

[Java 17 is required](https://github.com/eclipse-edc/GradlePlugins/blob/v0.5.1/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/JavaConvention.java#L30) now instead of Java 11.

## Linked Issue(s)

Closes #231
