### PR TITLE
fix: add dependency to keep runtime alive

### DIFF
--- a/basic/basic-01-basic-connector/build.gradle.kts
+++ b/basic/basic-01-basic-connector/build.gradle.kts
@@ -22,6 +22,7 @@ plugins {
 dependencies {
     implementation(libs.edc.boot)
     implementation(libs.edc.connector.core)
+    implementation(libs.edc.http)
 }
 
 application {


### PR DESCRIPTION
## What this PR changes/adds

Adds the `http` dependency to the basic-01 runtime.

## Why it does that

to keep it alive at startup, because the other dependencies (`boot` and `connector-core`) don't provide separated thread operations.

## Further notes

- maybe `boot` module should provide something that keeps the runtime alive until it gets shot down.

## Linked Issue(s)

Closes #303 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
