### PR TITLE
docs: remove management api appendix from basic-03

### DIFF
--- a/basic/basic-03-configuration/README.md
+++ b/basic/basic-03-configuration/README.md
@@ -143,37 +143,4 @@ There are a few things worth mentioning here:
 - it's better to pass the config value directly into the business logic than passing the
   entire `ServiceExtensionContext`, using configuration objects when there are more than one
 
-## Management API
-
-Part of most connectors will be the management api defined in the
-[`management-api`](https://github.com/eclipse-edc/Connector/tree/releases/extensions/control-plane/api/management-api)
-module. Therefore, we need to add the following module to the dependency list in our `build.gradle.kts`:
-
-```kotlin
-dependencies {
-    // ...
-    implementation(libs.edc.management.api)
-    // ...
-}
-```
-
-As described in the [README.md](https://github.com/eclipse-edc/Connector/tree/releases/extensions/common/api/management-api-configuration)
-of the `api-configuration module`, the management api should be exposed on a separate jetty context. Therefore, it is
-necessary to provide the following configuration to the connector:
-
-> Note: The ports could be chosen arbitrarily. In this example, they are aligned to the already existing `web.http.port` setting described above.
-
-```properties
-web.http.port=9191
-web.http.path=/api
-web.http.management.port=9192
-web.http.management.path=/management
-```
-
-_**Caution**: If you do not provide this configuration, it leads to the problem that the authentication mechanism is
-also applied to EVERY request in the _default_ context of Jetty, which includes the DSP communication between two
-connectors._
-
----
-
 [Previous Chapter](../basic-02-health-endpoint/README.md) 


### PR DESCRIPTION
## What this PR changes/adds

Remove the appendix about management-api because it's out of scope with the sample and it can get stale (as happened in #321 ).
Management API is already involved in `transfer` samples

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #321 
_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
