### PR TITLE
fix: add missing json fields for sample streaming http-to-http 

### DIFF
--- a/system-tests/src/test/java/org/eclipse/edc/samples/transfer/streaming/Streaming01httpToHttpTest.java
+++ b/system-tests/src/test/java/org/eclipse/edc/samples/transfer/streaming/Streaming01httpToHttpTest.java
@@ -96,22 +96,21 @@ public class Streaming01httpToHttpTest {
         PROVIDER.createPolicyDefinition(getFileContentFromRelativePath(SAMPLE_FOLDER + "/policy-definition.json"));
         PROVIDER.createContractDefinition(getFileContentFromRelativePath(SAMPLE_FOLDER + "/contract-definition.json"));
 
-	var catalogDatasetId = CONSUMER.fetchDatasetFromCatalog(getFileContentFromRelativePath(SAMPLE_FOLDER + "/get-dataset.json"));
+        var catalogDatasetId = CONSUMER.fetchDatasetFromCatalog(getFileContentFromRelativePath(SAMPLE_FOLDER + "/get-dataset.json"));
         var negotiateContractBody = getFileContentFromRelativePath(SAMPLE_FOLDER + "/negotiate-contract.json")
                                         .replace("{{offerId}}", catalogDatasetId);
-	//assertThat(catalogDatasetId).isEqualTo("test", catalogDatasetId);
         
         var contractNegotiationId = CONSUMER.negotiateContract(negotiateContractBody);
     
         await().atMost(TIMEOUT).untilAsserted(() -> {
-                var contractAgreementId = CONSUMER.getContractAgreementId(contractNegotiationId);
-                assertThat(contractAgreementId).isNotNull();
+            var contractAgreementId = CONSUMER.getContractAgreementId(contractNegotiationId);
+            assertThat(contractAgreementId).isNotNull();
         });
         var contractAgreementId = CONSUMER.getContractAgreementId(contractNegotiationId);
         
-	var requestBody = getFileContentFromRelativePath(SAMPLE_FOLDER + "/transfer.json")
+        var requestBody = getFileContentFromRelativePath(SAMPLE_FOLDER + "/transfer.json")
                                 .replace("{{contract-agreement-id}}", contractAgreementId)
-                                .replace("4000", ""+httpReceiverPort);
+                                .replace("4000", "" + httpReceiverPort);
 
         var transferProcessId = CONSUMER.startTransfer(requestBody);
 

--- a/system-tests/src/test/java/org/eclipse/edc/samples/transfer/streaming/Streaming01httpToHttpTest.java
+++ b/system-tests/src/test/java/org/eclipse/edc/samples/transfer/streaming/Streaming01httpToHttpTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.samples.transfer.streaming;
 
-import jakarta.json.Json;
 import okhttp3.mockwebserver.MockWebServer;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
@@ -97,14 +96,24 @@ public class Streaming01httpToHttpTest {
         PROVIDER.createPolicyDefinition(getFileContentFromRelativePath(SAMPLE_FOLDER + "/policy-definition.json"));
         PROVIDER.createContractDefinition(getFileContentFromRelativePath(SAMPLE_FOLDER + "/contract-definition.json"));
 
-        var destination = Json.createObjectBuilder()
-                .add("type", "HttpData")
-                .add("baseUrl", "http://localhost:" + httpReceiverPort)
-                .build();
-        var transferProcessId = CONSUMER.requestAssetFrom("stream-asset", PROVIDER)
-                .withDestination(destination)
-                .withTransferType("HttpData-PUSH")
-                .execute();
+	var catalogDatasetId = CONSUMER.fetchDatasetFromCatalog(getFileContentFromRelativePath(SAMPLE_FOLDER + "/get-dataset.json"));
+        var negotiateContractBody = getFileContentFromRelativePath(SAMPLE_FOLDER + "/negotiate-contract.json")
+                                        .replace("{{offerId}}", catalogDatasetId);
+	//assertThat(catalogDatasetId).isEqualTo("test", catalogDatasetId);
+        
+        var contractNegotiationId = CONSUMER.negotiateContract(negotiateContractBody);
+    
+        await().atMost(TIMEOUT).untilAsserted(() -> {
+                var contractAgreementId = CONSUMER.getContractAgreementId(contractNegotiationId);
+                assertThat(contractAgreementId).isNotNull();
+        });
+        var contractAgreementId = CONSUMER.getContractAgreementId(contractNegotiationId);
+        
+	var requestBody = getFileContentFromRelativePath(SAMPLE_FOLDER + "/transfer.json")
+                                .replace("{{contract-agreement-id}}", contractAgreementId)
+                                .replace("4000", ""+httpReceiverPort);
+
+        var transferProcessId = CONSUMER.startTransfer(requestBody);
 
         await().atMost(TIMEOUT).untilAsserted(() -> {
             var state = CONSUMER.getTransferProcessState(transferProcessId);

--- a/system-tests/src/test/java/org/eclipse/edc/samples/transfer/streaming/StreamingParticipant.java
+++ b/system-tests/src/test/java/org/eclipse/edc/samples/transfer/streaming/StreamingParticipant.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.connector.controlplane.test.system.utils.Participant;
 
 import static io.restassured.http.ContentType.JSON;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.hamcrest.Matchers.theInstance;
 
 /**
  * Essentially a wrapper around the management API enabling to test interactions with other participants, eg. catalog, transfer...
@@ -67,6 +68,53 @@ public class StreamingParticipant extends Participant {
                 .post("/v3/contractdefinitions")
                 .then()
                 .statusCode(200)
+                .extract().jsonPath().getString(ID);
+    }
+
+    public String fetchDatasetFromCatalog(String requestBody) {
+        return managementEndpoint.baseRequest()
+                .contentType(JSON)
+                .body(requestBody)
+                .when()
+                .post("/v3/catalog/dataset/request")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .extract().jsonPath().getString("'odrl:hasPolicy'.@id");
+    }
+
+    public String negotiateContract(String requestBody) {
+        return managementEndpoint.baseRequest()
+                .contentType(JSON)
+                .body(requestBody)
+                .when()
+                .post("/v3/contractnegotiations/")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .extract().jsonPath().getString(ID);
+    }
+
+    public String getContractAgreementId(String contractNegotiationId) {
+        return managementEndpoint.baseRequest()
+                .contentType(JSON)
+                .when()
+                .get("/v3/contractnegotiations/" + contractNegotiationId)
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .extract().jsonPath().getString("contractAgreementId");
+    }
+
+    public String startTransfer(String requestBody) {
+        return managementEndpoint.baseRequest()
+                .contentType(JSON)
+                .body(requestBody)
+                .when()
+                .post("/v3/transferprocesses")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
                 .extract().jsonPath().getString(ID);
     }
 

--- a/system-tests/src/test/java/org/eclipse/edc/samples/transfer/streaming/StreamingParticipant.java
+++ b/system-tests/src/test/java/org/eclipse/edc/samples/transfer/streaming/StreamingParticipant.java
@@ -18,7 +18,6 @@ import org.eclipse.edc.connector.controlplane.test.system.utils.Participant;
 
 import static io.restassured.http.ContentType.JSON;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
-import static org.hamcrest.Matchers.theInstance;
 
 /**
  * Essentially a wrapper around the management API enabling to test interactions with other participants, eg. catalog, transfer...

--- a/transfer/streaming/streaming-01-http-to-http/negotiate-contract.json
+++ b/transfer/streaming/streaming-01-http-to-http/negotiate-contract.json
@@ -1,18 +1,19 @@
 {
   "@context": {
-    "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
-    "odrl": "http://www.w3.org/ns/odrl/2/"
+    "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
   },
   "@type": "ContractRequest",
   "counterPartyAddress": "http://localhost:18182/protocol",
   "providerId": "provider",
   "protocol": "dataspace-protocol-http",
   "policy": {
+    "@context": "http://www.w3.org/ns/odrl.jsonld",
     "@id": "{{offerId}}",
     "@type": "Offer",
-    "odrl:permission": [],
-    "odrl:prohibition": [],
-    "odrl:obligation": [],
-    "odrl:target": "stream-asset"
-}
+    "permission": [],
+    "prohibition": [],
+    "obligation": [],
+    "assigner": "provider",
+    "target": "stream-asset"
+  }
 }

--- a/transfer/streaming/streaming-01-http-to-http/transfer.json
+++ b/transfer/streaming/streaming-01-http-to-http/transfer.json
@@ -11,5 +11,6 @@
   "assetId": "stream-asset",
   "contractId": "{{contract-agreement-id}}",
   "connectorId": "provider",
-  "counterPartyAddress": "http://localhost:18182/protocol"
+  "counterPartyAddress": "http://localhost:18182/protocol",
+  "transferType": "HttpData-PUSH"
 }


### PR DESCRIPTION
## What this PR changes/adds

Fixes issues #244 and #334 for sample transfer/streaming/streaming-01-http-to-http
- Missing `assigner` field in contract request
- Missing `transferType` in transfer request
- Did not use JSON files in testcase

## Why it does that
Sample can not be executed completely.

## Further notes


## Linked Issue(s)
Closes #244 
Closes #334
