### PR TITLE
fix: streaming-02-kafka-to-http:fix issues with contract negotiation …

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -12,7 +12,7 @@ runs:
       run: ${{ inputs.command }}
 
     - name: Upload Test Results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: Test Results ${{ github.job }}

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -49,7 +49,7 @@ jobs:
     if: always()
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: Publish Test Results

--- a/transfer/streaming/streaming-02-kafka-to-http/5-negotiate-contract.json
+++ b/transfer/streaming/streaming-02-kafka-to-http/5-negotiate-contract.json
@@ -1,18 +1,18 @@
 {
   "@context": {
-    "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
-    "odrl": "http://www.w3.org/ns/odrl/2/"
+    "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
   },
   "@type": "ContractRequest",
   "counterPartyAddress": "http://localhost:18182/protocol",
   "protocol": "dataspace-protocol-http",
   "policy": {
+    "@context": "http://www.w3.org/ns/odrl.jsonld",
     "@id": "{{offerId}}",
     "@type": "Offer",
-    "odrl:permission": [],
-    "odrl:prohibition": [],
-    "odrl:obligation": [],
-    "odrl:assigner": "provider",
-    "odrl:target": "kafka-stream-asset"
+    "permission": [],
+    "prohibition": [],
+    "obligation": [],
+    "assigner": "provider",
+    "target": "kafka-stream-asset"
   }
 }

--- a/transfer/streaming/streaming-02-kafka-to-http/6-transfer.json
+++ b/transfer/streaming/streaming-02-kafka-to-http/6-transfer.json
@@ -7,6 +7,7 @@
     "type": "HttpData",
     "baseUrl": "http://localhost:4000"
   },
+  "transferType": "HttpData-PUSH",
   "protocol": "dataspace-protocol-http",
   "assetId": "stream-asset",
   "contractId": "{{contract-agreement-id}}",


### PR DESCRIPTION
…and data transfer json requests

## What this PR changes/adds

Issues around running streaming-02-kafka-to-http sample. Issues with contract negotiation and date transfer 

Fixed transfer/streaming/streaming-02-kafka-to-http/5-negotiate-contract.json file by including the odrl context. 
Fixed transfer/streaming/streaming-02-kafka-to-http/6-transfer.json file by including the transfer type 

## Why it does that

The contract negotiation was failing because the contract definition was missing the ODRL context, which is required for policy evaluation. Adding the correct ODRL context ensures that contract negotiation can be processed successfully.  

Similarly, the transfer process was not working correctly because the transfer type was missing. Including the transfer type explicitly defines the expected data exchange format, allowing the transfer to proceed without errors.


## Linked Issue(s)

Closes #339

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
