### PR TITLE
Make HttpRequestLogger test container use free random port

### DIFF
--- a/system-tests/src/test/java/org/eclipse/edc/samples/transfer/Transfer03providerPushTest.java
+++ b/system-tests/src/test/java/org/eclipse/edc/samples/transfer/Transfer03providerPushTest.java
@@ -18,7 +18,6 @@ package org.eclipse.edc.samples.transfer;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
-import org.eclipse.edc.samples.util.HttpRequestLoggerConsumer;
 import org.eclipse.edc.samples.util.HttpRequestLoggerContainer;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -38,7 +37,6 @@ import static org.eclipse.edc.samples.util.TransferUtil.startTransfer;
 @Testcontainers
 public class Transfer03providerPushTest {
 
-    private static final HttpRequestLoggerConsumer LOG_CONSUMER = new HttpRequestLoggerConsumer();
     private static final String START_TRANSFER_FILE_PATH = "transfer/transfer-03-provider-push/resources/start-transfer.json";
 
     @RegisterExtension
@@ -48,7 +46,7 @@ public class Transfer03providerPushTest {
     static RuntimeExtension consumer = getConsumer();
 
     @Container
-    public static HttpRequestLoggerContainer httpRequestLoggerContainer = new HttpRequestLoggerContainer(LOG_CONSUMER);
+    public static HttpRequestLoggerContainer httpRequestLoggerContainer = new HttpRequestLoggerContainer();
 
     @BeforeAll
     static void setUp() {
@@ -58,9 +56,10 @@ public class Transfer03providerPushTest {
     @Test
     void runSampleSteps() {
         var contractAgreementId = runNegotiation();
-        var requestBody = getFileContentFromRelativePath(START_TRANSFER_FILE_PATH);
+        var requestBody = getFileContentFromRelativePath(START_TRANSFER_FILE_PATH)
+                .replace("4000", String.valueOf(httpRequestLoggerContainer.getPort()));
         var transferProcessId = startTransfer(requestBody, contractAgreementId);
         checkTransferStatus(transferProcessId, TransferProcessStates.COMPLETED);
-        assertThat(LOG_CONSUMER.toUtf8String()).contains("Leanne Graham");
+        assertThat(httpRequestLoggerContainer.getLogConsumerUtf8String()).contains("Leanne Graham");
     }
 }

--- a/system-tests/src/test/java/org/eclipse/edc/samples/util/HttpRequestLoggerContainer.java
+++ b/system-tests/src/test/java/org/eclipse/edc/samples/util/HttpRequestLoggerContainer.java
@@ -14,11 +14,10 @@
 
 package org.eclipse.edc.samples.util;
 
+import org.eclipse.edc.util.io.Ports;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.ToStringConsumer;
 import org.testcontainers.images.builder.ImageFromDockerfile;
-
-import java.util.List;
 
 import static org.eclipse.edc.samples.common.FileTransferCommon.getFileFromRelativePath;
 
@@ -27,15 +26,22 @@ public class HttpRequestLoggerContainer extends GenericContainer<HttpRequestLogg
     private static final String HTTP_REQUEST_LOGGER_DOCKERFILE_PATH = "util/http-request-logger/Dockerfile";
     private static final ImageFromDockerfile IMAGE_FROM_DOCKERFILE = new ImageFromDockerfile()
             .withDockerfile(getFileFromRelativePath(HTTP_REQUEST_LOGGER_DOCKERFILE_PATH).toPath());
-    private static final String PORT_BINDING = "4000:4000";
+    private final ToStringConsumer toStringConsumer;
+    private final int port;
 
     public HttpRequestLoggerContainer() {
         super(IMAGE_FROM_DOCKERFILE);
-        this.setPortBindings(List.of(PORT_BINDING));
+        this.toStringConsumer =  new HttpRequestLoggerConsumer();
+        this.port =  Ports.getFreePort();
+        this.withLogConsumer(toStringConsumer)
+                .addFixedExposedPort(this.port, 4000);
     }
 
-    public HttpRequestLoggerContainer(ToStringConsumer toStringConsumer) {
-        this();
-        this.setLogConsumers(List.of(toStringConsumer));
+    public String getLogConsumerUtf8String() {
+        return this.toStringConsumer.toUtf8String();
+    }
+
+    public int getPort() {
+        return this.port;
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

HttpRequestLogger test container now uses random free ports to avoid errors while running the tests


## Linked Issue(s)

Closes #359

## Sponsor
@ndr-brt 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
