### PR TITLE
fix: sample streaming-03 kafka broker sample

### DIFF
--- a/transfer/streaming/streaming-03-kafka-broker/5-negotiate-contract.json
+++ b/transfer/streaming/streaming-03-kafka-broker/5-negotiate-contract.json
@@ -1,18 +1,18 @@
 {
   "@context": {
-    "edc": "https://w3id.org/edc/v0.0.1/ns/",
-    "odrl": "http://www.w3.org/ns/odrl/2/"
+    "edc": "https://w3id.org/edc/v0.0.1/ns/"
   },
   "@type": "ContractRequest",
   "counterPartyAddress": "http://localhost:18182/protocol",
   "protocol": "dataspace-protocol-http",
   "policy": {
+    "@context": "http://www.w3.org/ns/odrl.jsonld",
     "@id": "{{offerId}}",
     "@type": "Offer",
-    "odrl:permission": [],
-    "odrl:prohibition": [],
-    "odrl:obligation": [],
-    "odrl:assigner": "provider",
-    "odrl:target": "kafka-stream-asset"
+    "permission": [],
+    "prohibition": [],
+    "obligation": [],
+    "assigner": "provider",
+    "target": "kafka-stream-asset"
   }
 }

--- a/transfer/streaming/streaming-03-kafka-broker/6-transfer.json
+++ b/transfer/streaming/streaming-03-kafka-broker/6-transfer.json
@@ -1,13 +1,14 @@
 {
   "@context": {
-    "edc": "https://w3id.org/edc/v0.0.1/ns/"
+    "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
   },
   "@type": "TransferRequest",
-  "dataDestination": {
-    "type": "KafkaBroker"
-  },
   "protocol": "dataspace-protocol-http",
+  "transferType": "KafkaBroker-PULL",
   "contractId": "{{contract-agreement-id}}",
   "connectorId": "provider",
-  "connectorAddress": "http://localhost:18182/protocol"
+  "counterPartyAddress": "http://localhost:18182/protocol",
+  "privateProperties": {
+    "receiverHttpEndpoint" : "http://localhost:4000"
+  }
 }


### PR DESCRIPTION
## What this PR changes/adds

Issues around running streaming-03-kafka-broker sample. Issues with contract negotiation and data transfer

Fixed transfer/streaming/streaming-03-kafka-broker/5-negotiate-contract.json file by including the odrl context.
Fixed transfer/streaming/streaming-023-kafka-broker/6-transfer.json file by including the transfer type and the private properties

## Why it does that

The transfer process was not working correctly because the transfer type was missing. Including the transfer type explicitly defines the expected data exchange format, allowing the transfer to proceed without errors.


## Who will sponsor this feature?
@ndr-brt


## Linked Issue(s)

Closes #372 
