### PR TITLE
fix: sample 03

### DIFF
--- a/system-tests/src/test/java/org/eclipse/edc/samples/transfer/Transfer04eventConsumerTest.java
+++ b/system-tests/src/test/java/org/eclipse/edc/samples/transfer/Transfer04eventConsumerTest.java
@@ -38,7 +38,7 @@ import static org.eclipse.edc.samples.util.TransferUtil.startTransfer;
 @EndToEndTest
 public class Transfer04eventConsumerTest {
     private static final String CONSUMER_WITH_LISTENER_MODULE_PATH = ":transfer:transfer-04-event-consumer:consumer-with-listener";
-    private static final String START_TRANSFER_FILE_PATH = "transfer/transfer-03-consumer-pull/resources/start-transfer.json";
+    private static final String START_TRANSFER_FILE_PATH = "transfer/transfer-02-provider-push/resources/start-transfer.json";
 
     @RegisterExtension
     static RuntimeExtension provider = getProvider();

--- a/transfer/transfer-00-prerequisites/connector/build.gradle.kts
+++ b/transfer/transfer-00-prerequisites/connector/build.gradle.kts
@@ -42,7 +42,6 @@ dependencies {
 
     implementation(libs.edc.data.plane.self.registration)
     implementation(libs.edc.data.plane.signaling.api)
-    implementation(libs.edc.data.plane.public.api)
     implementation(libs.edc.data.plane.core)
     implementation(libs.edc.data.plane.http)
     implementation(libs.edc.data.plane.iam)

--- a/transfer/transfer-01-negotiation/README.md
+++ b/transfer/transfer-01-negotiation/README.md
@@ -51,13 +51,6 @@ curl -d @transfer/transfer-01-negotiation/resources/create-asset.json \
 > the purpose of this example. It will be the data that the consumer will pull on the sample
 > execution.
 
-Additional properties on `HttpData` can be used to allow consumers to enrich the data request:
-
-- `proxyPath`: allows specifying additional path segments.
-- `proxyQueryParams`: allows specifying query params.
-- `proxyBody`: allows attaching a body.
-- `proxyMethod`: allows specifying the Http Method (default `GET`)
-
 ### 2. Create a Policy on the provider
 
 In order to manage the accessibility rules of an asset, it is essential to create a policy. However,

--- a/transfer/transfer-02-provider-push/README.md
+++ b/transfer/transfer-02-provider-push/README.md
@@ -17,7 +17,7 @@ This samples consists of:
 The following steps assume your provider and consumer connectors are still up and running and contract
 negotiation has taken place successfully. Furthermore, the http server should be up as well.
 If not, re-visit the [Prerequisites](../transfer-00-prerequisites/README.md)
-, [Negotiation](../transfer-01-negotiation/README.md) and [Consumer Pull](../transfer-03-consumer-pull/README.md) chapters.
+and [Negotiation](../transfer-01-negotiation/README.md) chapters.
 
 # Run the sample
 

--- a/transfer/transfer-03-consumer-pull/provider-proxy-data-plane/build.gradle.kts
+++ b/transfer/transfer-03-consumer-pull/provider-proxy-data-plane/build.gradle.kts
@@ -23,9 +23,7 @@ dependencies {
     implementation(libs.edc.data.plane.spi)
     implementation(libs.edc.web.spi)
 
-    runtimeOnly(project(":transfer:transfer-00-prerequisites:connector")) {
-        exclude("org.eclipse.edc", "data-plane-public-api-v2")
-    }
+    runtimeOnly(project(":transfer:transfer-00-prerequisites:connector"))
 }
 
 application {

--- a/transfer/transfer-04-event-consumer/README.md
+++ b/transfer/transfer-04-event-consumer/README.md
@@ -1,6 +1,6 @@
 # Implement a simple event consumer
 
-In this sample, we build upon the [Consumer Pull](../transfer-03-consumer-pull/README.md) chapter to add functionality
+In this sample, we build upon the [Provider push](../transfer-02-provider-push/README.md) chapter to add functionality
 to react to transfer completion on the consumer connector side.
 
 Also, in order to keep things organized, the code in this example has been separated into several Java modules:
@@ -85,13 +85,24 @@ curl -X GET "http://localhost:29193/management/v3/contractnegotiations/{{contrac
 
 ### 4. Perform a file transfer
 
-Replace the `contractId` property inside the [request body](../transfer-03-consumer-pull/resources/start-transfer.json) with the contract agreement id from the previous call.
+#### Start a http server
+
+As a pre-requisite, you need to have a logging webserver that runs on port 4000 and logs all the incoming requests, the
+data will be sent to this server.
+
+```bash
+docker build -t http-request-logger util/http-request-logger
+docker run -p 4000:4000 http-request-logger
+```
+
+Replace the `contractId` property inside the [request body](../transfer-02-provider-push/resources/start-transfer.json)
+with the contract agreement id from the previous call.
 Afterward run:
 
 ```bash
 curl -X POST "http://localhost:29193/management/v3/transferprocesses" \
   -H "Content-Type: application/json" \
-  -d @transfer/transfer-03-consumer-pull/resources/start-transfer.json \
+  -d @transfer/transfer-02-provider-push/resources/start-transfer.json \
   -s | jq
 ```
 
@@ -100,10 +111,7 @@ curl -X POST "http://localhost:29193/management/v3/transferprocesses" \
 The consumer should spew out logs similar to:
 
 ```bash
-DEBUG 2023-10-16T09:29:45.316908 [TransferProcessManagerImpl] TransferProcess 762b5a0c-43fb-4b8b-8022-669043c8fa81 is now in state REQUESTED
-DEBUG 2023-10-16T09:29:46.269998 DSP: Incoming TransferStartMessage for class org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess process: 762b5a0c-43fb-4b8b-8022-669043c8fa81
-DEBUG 2023-10-16T09:29:46.271592 TransferProcessStartedListener received STARTED event   <----------------------------
-DEBUG 2023-10-16T09:29:46.27174 TransferProcess 762b5a0c-43fb-4b8b-8022-669043c8fa81 is now in state STARTED
+INFO 2023-10-16T09:29:46.271592 TransferProcessStartedListener received STARTED event   <----------------------------
 ```
 
 If you see the `TransferProcessStartedListener received STARTED event` log message, it means that your event consumer has been

--- a/transfer/transfer-04-event-consumer/listener/src/main/java/org/eclipse/edc/sample/extension/listener/TransferProcessStartedListener.java
+++ b/transfer/transfer-04-event-consumer/listener/src/main/java/org/eclipse/edc/sample/extension/listener/TransferProcessStartedListener.java
@@ -33,7 +33,7 @@ public class TransferProcessStartedListener implements TransferProcessListener {
      */
     @Override
     public void preStarted(final TransferProcess process) {
-        monitor.debug("TransferProcessStartedListener received STARTED event");
+        monitor.info("TransferProcessStartedListener received STARTED event");
         // do something meaningful before transfer start
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Remove `public-api` module from "prerequisites" connector

## Why it does that

Avoid conflicts with the proxy extension

## Further notes

- had to fix transfer-04 because it was relying on transfer-03 but the provider was the one without the http proxy capabilities, now transfer-04 is based on transfer-02 (push)


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #376 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
