### PR TITLE
fix(config): fix policy-enforcement-consumer config

### DIFF
--- a/policy/policy-01-policy-enforcement/policy-enforcement-consumer/config.properties
+++ b/policy/policy-01-policy-enforcement/policy-enforcement-consumer/config.properties
@@ -3,7 +3,7 @@ web.http.path=/api
 web.http.management.port=29193
 web.http.management.path=/management
 web.http.protocol.port=29194
-web.http.protocol.path=/protocol\
+web.http.protocol.path=/protocol
 web.http.version.port=29195
 web.http.version.path=/version
 


### PR DESCRIPTION
## What this PR changes/adds

This PR removes the trailing backslash from the `web.http.protocol.path` property in `config.properties`, changing it from `/protocol\` to `/protocol`.

## Why it does that

The trailing backslash was likely unintentional or could cause misinterpretation of the path. Removing it ensures the property value is properly interpreted and aligns with expected URL path formatting.

## Further notes

No other areas of code were affected. This is a minor configuration fix.

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #396 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
