### PR TITLE
chore: update README for basic-01-basic-connector

### DIFF
--- a/basic/basic-01-basic-connector/README.md
+++ b/basic/basic-01-basic-connector/README.md
@@ -4,25 +4,38 @@ A runnable connector consists of a `Runtime` and a build file, in our case this 
 
 The first thing we need is the `Runtime` which is the main entry point to the connector application, same as with any
 other Java program. In this sample we use the
-[`BaseRuntime`](https://github.com/eclipse-edc/Connector/blob/releases/core/common/boot/src/main/java/org/eclipse/edc/boot/system/runtime/BaseRuntime.java),
-but this can be extended (take a look at the [`custom-runtime`](../../advanced/advanced-02-custom-runtime) sample for more information)
+[
+`BaseRuntime`](https://github.com/eclipse-edc/Connector/blob/releases/core/common/boot/src/main/java/org/eclipse/edc/boot/system/runtime/BaseRuntime.java),
+but this can be extended (take a look at the [`custom-runtime`](../../advanced/advanced-02-custom-runtime) sample for
+more information)
 
 The second thing we need is a [gradle build file](build.gradle.kts)
 that contains the essential dependencies. We'll need at least the following things:
 
 ```kotlin
 dependencies {
-    implementation(libs.edc.control.plane.core)
+    implementation(libs.edc.boot)
+    implementation(libs.edc.connector.core)
+}
+```
+
+However, the connector would directly shut down after the successful boot due to no extension is loaded and nothing
+happens. To avoid this behavior the [gradle build file](build.gradle.kts) includes already another dependency that we
+will re-use in the next samples:
+
+```kotlin
+dependencies {
+    implementation(libs.edc.http)
 }
 ```
 
 > _Additional dependencies will be added to this list in the future, so be sure to check back regularly!_
 
-with that we can build and run the connector from the root directory:
+With that we can build and run the connector from the root directory:
 
 ```bash
 ./gradlew clean basic:basic-01-basic-connector:build
-java -jar basic/basic-01-basic-connector/build/libs/basic-connector.jar
+java -jar basic/basic-01-basic-connector/build/libs/basic-connector.jar --log-level=DEBUG
 ```
 
 _Note: the above snippet assumes that you did not alter the build file, i.e. the `shadow` plugin is used and the build


### PR DESCRIPTION
## What this PR changes/adds

The PR changes the README of the _basic-01-basic-connector_ sample to correct the statement about the dependencies loaded via the grade build file.

Further it sets the log level to DEBUG to achieve the expected output with `--log-level=DEBUG`  

## Why it does that

Update the sample description to meet the current version and requirement through the change in log-level handling.
