### PR TITLE
fix(policy/enforcement): update README for policy 01

### DIFF
--- a/policy/policy-01-policy-enforcement/README.md
+++ b/policy/policy-01-policy-enforcement/README.md
@@ -404,7 +404,9 @@ a consumer cannot negotiate an offer it is not allowed to see.
 ```java
   import org.eclipse.edc.connector.controlplane.catalog.spi.policy.CatalogPolicyContext;
   import static org.eclipse.edc.connector.controlplane.catalog.spi.policy.CatalogPolicyContext.CATALOG_SCOPE;
-
+  
+  //...
+          
   ruleBindingRegistry.bind(LOCATION_CONSTRAINT_KEY, CATALOG_SCOPE);
   policyEngine.registerFunction(CatalogPolicyContext.class, Permission.class, LOCATION_CONSTRAINT_KEY, new LocationConstraintFunction(monitor));
 ```

--- a/policy/policy-01-policy-enforcement/README.md
+++ b/policy/policy-01-policy-enforcement/README.md
@@ -400,7 +400,18 @@ to the negotiation scope anymore, the negotiation will be terminated. When recei
 the provider will still evaluate its contract definitions' access policies using the catalog scope, to ensure that
 a consumer cannot negotiate an offer it is not allowed to see.
 
+
 ```java
-ruleBindingRegistry.bind(LOCATION_CONSTRAINT_KEY, CATALOGING_SCOPE);
-policyEngine.registerFunction(CATALOGING_SCOPE, Permission.class, LOCATION_CONSTRAINT_KEY, new LocationConstraintFunction(monitor));
+  import org.eclipse.edc.connector.controlplane.catalog.spi.policy.CatalogPolicyContext;
+  import static org.eclipse.edc.connector.controlplane.catalog.spi.policy.CatalogPolicyContext.CATALOG_SCOPE;
+
+  ruleBindingRegistry.bind(LOCATION_CONSTRAINT_KEY, CATALOG_SCOPE);
+  policyEngine.registerFunction(CatalogPolicyContext.class, Permission.class, LOCATION_CONSTRAINT_KEY, new LocationConstraintFunction(monitor));
+```
+
+Let's change ContractNegotiationPolicyContext by CatalogPolicyContext in LocationConstraintFunction.java
+
+```java
+    public class LocationConstraintFunction implements AtomicConstraintRuleFunction<Permission, CatalogPolicyContext>
+    public boolean evaluate(Operator operator, Object rightValue, Permission rule, CatalogPolicyContext context) 
 ```

--- a/policy/policy-01-policy-enforcement/README.md
+++ b/policy/policy-01-policy-enforcement/README.md
@@ -402,11 +402,6 @@ a consumer cannot negotiate an offer it is not allowed to see.
 
 
 ```java
-  import org.eclipse.edc.connector.controlplane.catalog.spi.policy.CatalogPolicyContext;
-  import static org.eclipse.edc.connector.controlplane.catalog.spi.policy.CatalogPolicyContext.CATALOG_SCOPE;
-  
-  //...
-          
   ruleBindingRegistry.bind(LOCATION_CONSTRAINT_KEY, CATALOG_SCOPE);
   policyEngine.registerFunction(CatalogPolicyContext.class, Permission.class, LOCATION_CONSTRAINT_KEY, new LocationConstraintFunction(monitor));
 ```

--- a/policy/policy-01-policy-enforcement/README.md
+++ b/policy/policy-01-policy-enforcement/README.md
@@ -411,7 +411,7 @@ a consumer cannot negotiate an offer it is not allowed to see.
   policyEngine.registerFunction(CatalogPolicyContext.class, Permission.class, LOCATION_CONSTRAINT_KEY, new LocationConstraintFunction(monitor));
 ```
 
-Let's change ContractNegotiationPolicyContext by CatalogPolicyContext in LocationConstraintFunction.java
+Let's change ContractNegotiationPolicyContext with CatalogPolicyContext in LocationConstraintFunction.java
 
 ```java
     public class LocationConstraintFunction implements AtomicConstraintRuleFunction<Permission, CatalogPolicyContext>

--- a/policy/policy-01-policy-enforcement/README.md
+++ b/policy/policy-01-policy-enforcement/README.md
@@ -415,5 +415,5 @@ Let's change ContractNegotiationPolicyContext with CatalogPolicyContext in Locat
 
 ```java
     public class LocationConstraintFunction implements AtomicConstraintRuleFunction<Permission, CatalogPolicyContext>
-    public boolean evaluate(Operator operator, Object rightValue, Permission rule, CatalogPolicyContext context) 
+        public boolean evaluate(Operator operator, Object rightValue, Permission rule, CatalogPolicyContext context) 
 ```


### PR DESCRIPTION
## What this PR changes/adds

This PR updates the policy-01-policy-enforcement/README.md file to fix and clarify the instructions for running and testing the provided code.

### Context

While going through the README to test the code, I noticed that some of the final instructions **(Bind the constraint to the cataloging scope)**  didn’t work as expected. After a bit of trial and error, I found that a few parts were either outdated or incorrect.

This is what i found:

1. The CATALOGING_SCOPE doesn’t seem to exist. The actual constant is CATALOG_SCOPE, and the correct context class to use with policyEngine.registerFunction is CatalogPolicyContext.class.

2. The import statement for the correct constant (CATALOG_SCOPE) was missing.

3. A code change in LocationConstraintFunction.java is also needed. This wasn't mentioned in the README, but in order for everything to work, the LocationConstraintFunction class needs to be updated to use CatalogPolicyContext instead of ContractNegotiationPolicyContext.

## Who will sponsor this feature?

[ndr-brt](https://github.com/ndr-brt)

## Linked Issue(s)

Closes #245

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
