### PR TITLE
fix: add missing shadow jar config

### DIFF
--- a/advanced/advanced-02-custom-runtime/build.gradle.kts
+++ b/advanced/advanced-02-custom-runtime/build.gradle.kts
@@ -37,4 +37,5 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("custom-runtime.jar")
     dependsOn(distTar, distZip)
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }

--- a/basic/basic-01-basic-connector/README.md
+++ b/basic/basic-01-basic-connector/README.md
@@ -36,7 +36,7 @@ With that we can build and run the connector from the root directory:
 
 ```bash
 ./gradlew clean basic:basic-01-basic-connector:build
-java -jar basic/basic-01-basic-connector/build/libs/basic-connector.jar --log-level=DEBUG
+java -jar basic/basic-01-basic-connector/build/libs/basic-connector.jar
 ```
 
 _Note: the above snippet assumes that you did not alter the build file, i.e. the `shadow` plugin is used and the build
@@ -46,25 +46,13 @@ installation._
 If everything works as intended you should see command-line output similar to this:
 
 ```bash
-INFO 2022-01-13T13:43:57.677973407 Secrets vault not configured. Defaulting to null vault.
-INFO 2022-01-13T13:43:57.680158117 Initialized Null Vault
-INFO 2022-01-13T13:43:57.851181615 Initialized Core Services
-INFO 2022-01-13T13:43:57.852046576 Initialized Schema Registry
-INFO 2022-01-13T13:43:57.853010987 Initialized In-Memory Transfer Process Store
-INFO 2022-01-13T13:43:57.856956651 Initialized Core Transfer
-INFO 2022-01-13T13:43:57.857664924 Initialized In-Memory Asset Index
-INFO 2022-01-13T13:43:57.857957714 Initialized In-Memory Contract Definition Store
-INFO 2022-01-13T13:43:57.860738605 Initialized Core Contract Service
-INFO 2022-01-13T13:43:57.861390422 Initialized In-Memory Contract Negotiation Store
-INFO 2022-01-13T13:43:57.862002044 Started Core Services
-INFO 2022-01-13T13:43:57.862247712 Started Schema Registry
-INFO 2022-01-13T13:43:57.862782289 Started In-Memory Transfer Process Store
-INFO 2022-01-13T13:43:57.8635804 Started Core Transfer
-INFO 2022-01-13T13:43:57.86371948 Started In-Memory Asset Index
-INFO 2022-01-13T13:43:57.863838751 Started In-Memory Contract Definition Store
-INFO 2022-01-13T13:43:57.86497334 Started Core Contract Service
-INFO 2022-01-13T13:43:57.865146132 Started In-Memory Contract Negotiation Store
-INFO 2022-01-13T13:43:57.866073376 edc-e796b518-35f0-4c45-a333-79ca20a6be06 ready
+INFO 2025-09-22T09:28:34.533664939 Booting EDC runtime
+WARNING 2025-09-22T09:28:34.557375883 The runtime is configured as an anonymous participant. DO NOT DO THIS IN PRODUCTION.
+INFO 2025-09-22T09:28:34.6675347 HTTPS enforcement it not enabled, please enable it in a production environment
+WARNING 2025-09-22T09:28:34.774747827 Config value: no setting found for 'edc.hostname', falling back to default value 'localhost'
+WARNING 2025-09-22T09:28:34.88495366 Using the InMemoryVault is not suitable for production scenarios and should be replaced with an actual Vault!
+INFO 2025-09-22T09:28:35.031852619 9 service extensions started
+INFO 2025-09-22T09:28:35.032885401 Runtime e1fb90ce-63a0-4d6b-bcdf-8c998b67f41b ready
 ```
 
 This basic connector - while perfectly fine - does not offer any outward-facing API, nor does it provide any

--- a/basic/basic-01-basic-connector/build.gradle.kts
+++ b/basic/basic-01-basic-connector/build.gradle.kts
@@ -33,4 +33,5 @@ application {
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("basic-connector.jar")
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }

--- a/basic/basic-02-health-endpoint/build.gradle.kts
+++ b/basic/basic-02-health-endpoint/build.gradle.kts
@@ -36,4 +36,5 @@ application {
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("connector-health.jar")
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }

--- a/basic/basic-03-configuration/build.gradle.kts
+++ b/basic/basic-03-configuration/build.gradle.kts
@@ -39,4 +39,5 @@ application {
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("filesystem-config-connector.jar")
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }

--- a/federated-catalog/fc-01-embedded/fc-connector/build.gradle.kts
+++ b/federated-catalog/fc-01-embedded/fc-connector/build.gradle.kts
@@ -45,4 +45,5 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("fc-connector.jar")
     dependsOn(distTar, distZip)
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }

--- a/federated-catalog/fc-02-standalone/standalone-fc/build.gradle.kts
+++ b/federated-catalog/fc-02-standalone/standalone-fc/build.gradle.kts
@@ -45,4 +45,5 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("standalone-fc.jar")
     dependsOn(distTar, distZip)
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }

--- a/federated-catalog/fc-03-static-node-directory/embedded-fc-with-node-resolver/build.gradle.kts
+++ b/federated-catalog/fc-03-static-node-directory/embedded-fc-with-node-resolver/build.gradle.kts
@@ -45,4 +45,5 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("fc-connector-with-node-resolver.jar")
     dependsOn(distTar, distZip)
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }

--- a/federated-catalog/fc-03-static-node-directory/standalone-fc-with-node-resolver/build.gradle.kts
+++ b/federated-catalog/fc-03-static-node-directory/standalone-fc-with-node-resolver/build.gradle.kts
@@ -46,4 +46,5 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("standalone-fc-with-node-resolver.jar")
     dependsOn(distTar, distZip)
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }

--- a/policy/policy-01-policy-enforcement/policy-enforcement-consumer/build.gradle.kts
+++ b/policy/policy-01-policy-enforcement/policy-enforcement-consumer/build.gradle.kts
@@ -37,4 +37,5 @@ application {
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("consumer.jar")
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }

--- a/policy/policy-01-policy-enforcement/policy-enforcement-provider/build.gradle.kts
+++ b/policy/policy-01-policy-enforcement/policy-enforcement-provider/build.gradle.kts
@@ -40,4 +40,5 @@ application {
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("provider.jar")
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }

--- a/transfer/transfer-00-prerequisites/connector/build.gradle.kts
+++ b/transfer/transfer-00-prerequisites/connector/build.gradle.kts
@@ -59,4 +59,5 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("connector.jar")
     dependsOn(distTar, distZip)
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }

--- a/transfer/transfer-03-consumer-pull/provider-proxy-data-plane/build.gradle.kts
+++ b/transfer/transfer-03-consumer-pull/provider-proxy-data-plane/build.gradle.kts
@@ -41,4 +41,5 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("connector.jar")
     dependsOn(distTar, distZip)
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }

--- a/transfer/transfer-04-event-consumer/consumer-with-listener/build.gradle.kts
+++ b/transfer/transfer-04-event-consumer/consumer-with-listener/build.gradle.kts
@@ -62,4 +62,5 @@ tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("connector.jar")
     dependsOn(distTar, distZip)
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }

--- a/transfer/transfer-05-file-transfer-cloud/cloud-transfer-consumer/build.gradle.kts
+++ b/transfer/transfer-05-file-transfer-cloud/cloud-transfer-consumer/build.gradle.kts
@@ -54,4 +54,5 @@ application {
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("consumer.jar")
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }

--- a/transfer/transfer-05-file-transfer-cloud/cloud-transfer-provider/build.gradle.kts
+++ b/transfer/transfer-05-file-transfer-cloud/cloud-transfer-provider/build.gradle.kts
@@ -57,4 +57,5 @@ application {
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("provider.jar")
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }

--- a/transfer/transfer-06-kafka-broker/kafka-runtime/build.gradle.kts
+++ b/transfer/transfer-06-kafka-broker/kafka-runtime/build.gradle.kts
@@ -36,4 +36,5 @@ application {
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     mergeServiceFiles()
     archiveFileName.set("connector.jar")
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }


### PR DESCRIPTION
## What this PR changes/adds

Add missing `duplicatesStrategy = DuplicatesStrategy.INCLUDE` setting for shadow plugin that become mandatory to permit proper service file merging.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #459 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
