### PR TITLE
fix(policy/enforcement): update README for policy 01

### DIFF
--- a/policy/policy-01-policy-enforcement/README.md
+++ b/policy/policy-01-policy-enforcement/README.md
@@ -324,8 +324,8 @@ In the response we'll get a description of the negotiation, similar to the follo
 ```json
 {
   ...
-  "edc:contractAgreementId": null,
   "edc:state": "TERMINATED",
+  "edc:errorDetail": "Failed to send termination to counter party: Value in JsonObjects name/value pair cannot be null",
   ...
 }
 ```


### PR DESCRIPTION
## What this PR changes/adds

This PR fixes a small issue in the policy-01-policy-enforcement README.

Previously, the example response for the contract negotiation state was incorrect: following the instructions would not produce the response shown in the README.

Mistaken response:

```json
{
  "edc:state": "TERMINATED",
  "edc:contractAgreementId": null
}
```

Correct response:

```json

{
  "edc:state": "TERMINATED",
  "edc:errorDetail": "Failed to send termination to counter party: Value in JsonObjects name/value pair cannot be null"
}
````

This update ensures that the README matches the actual response from the system.

## Who will sponsor this feature?

@ndr-brt 


## Linked Issue(s)

Closes #456 #456


