### PR TITLE
build: upgrade docker base images

### DIFF
--- a/advanced/advanced-01-open-telemetry/open-telemetry-runtime/Dockerfile
+++ b/advanced/advanced-01-open-telemetry/open-telemetry-runtime/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-slim
+FROM eclipse-temurin:25-alpine
 
 WORKDIR /app
 COPY build/otel/opentelemetry-javaagent.jar /app/opentelemetry-javaagent.jar

--- a/util/http-request-logger/Dockerfile
+++ b/util/http-request-logger/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /home/gradle/project
 COPY --chown=gradle:gradle . /home/gradle/project
 RUN gradle build
 
-FROM openjdk:17-slim
+FROM eclipse-temurin:25-alpine
 
 WORKDIR /app
 COPY --from=build /home/gradle/project/build/libs/http-request-logger.jar /app/http-request-logger.jar


### PR DESCRIPTION
## What this PR changes/adds

swap docker base images from `openjdk:17-slim` to `eclipse-temurin:25-alpine`

## Why it does that

the openjdk one wasn't working anymore

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
