### PR TITLE
refactor: update sample DSP requests to 2025-1

### DIFF
--- a/advanced/advanced-01-open-telemetry/README.md
+++ b/advanced/advanced-01-open-telemetry/README.md
@@ -99,9 +99,9 @@ The output will be something like:
         "@id": "cb701b36-48ee-4132-8436-dba7b83c606c",
         "@type": "dcat:DataService",
         "dcat:endpointDescription": "dspace:connector",
-        "dcat:endpointUrl": "http://provider:19194/protocol",
+        "dcat:endpointUrl": "http://provider:19194/protocol/2025-1",
         "dct:terms": "dspace:connector",
-        "dct:endpointUrl": "http://provider:19194/protocol"
+        "dct:endpointUrl": "http://provider:19194/protocol/2025-1"
       }
     },
     {
@@ -113,9 +113,9 @@ The output will be something like:
         "@id": "cb701b36-48ee-4132-8436-dba7b83c606c",
         "@type": "dcat:DataService",
         "dcat:endpointDescription": "dspace:connector",
-        "dcat:endpointUrl": "http://provider:19194/protocol",
+        "dcat:endpointUrl": "http://provider:19194/protocol/2025-1",
         "dct:terms": "dspace:connector",
-        "dct:endpointUrl": "http://provider:19194/protocol"
+        "dct:endpointUrl": "http://provider:19194/protocol/2025-1"
       }
     }
   ],
@@ -128,7 +128,7 @@ The output will be something like:
     "dcat": "http://www.w3.org/ns/dcat#",
     "dct": "http://purl.org/dc/terms/",
     "odrl": "http://www.w3.org/ns/odrl/2/",
-    "dspace": "https://w3id.org/dspace/v0.8/"
+    "dspace": "https://w3id.org/dspace/2025/1/"
   }
 }
 

--- a/advanced/advanced-01-open-telemetry/resources/get-dataset.json
+++ b/advanced/advanced-01-open-telemetry/resources/get-dataset.json
@@ -2,6 +2,7 @@
   "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
   "@type": "DatasetRequest",
   "@id": "assetId",
-  "counterPartyAddress": "http://provider:19194/protocol",
-  "protocol": "dataspace-protocol-http"
+  "counterPartyId": "provider",
+  "counterPartyAddress": "http://provider:19194/protocol/2025-1",
+  "protocol": "dataspace-protocol-http:2025-1"
 }

--- a/advanced/advanced-01-open-telemetry/resources/negotiate-contract.json
+++ b/advanced/advanced-01-open-telemetry/resources/negotiate-contract.json
@@ -3,8 +3,9 @@
     "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
   },
   "@type": "ContractRequest",
-  "counterPartyAddress": "http://provider:19194/protocol",
-  "protocol": "dataspace-protocol-http",
+  "counterPartyId": "provider",
+  "counterPartyAddress": "http://provider:19194/protocol/2025-1",
+  "protocol": "dataspace-protocol-http:2025-1",
   "policy": {
     "@context": "http://www.w3.org/ns/odrl.jsonld",
     "@id": "{{contract-offer-id}}",

--- a/advanced/advanced-01-open-telemetry/resources/start-transfer.json
+++ b/advanced/advanced-01-open-telemetry/resources/start-transfer.json
@@ -4,8 +4,8 @@
   },
   "@type": "TransferRequestDto",
   "connectorId": "provider",
-  "counterPartyAddress": "http://provider:19194/protocol",
+  "counterPartyAddress": "http://provider:19194/protocol/2025-1",
   "contractId": "{{contract-agreement-id}}",
-  "protocol": "dataspace-protocol-http",
+  "protocol": "dataspace-protocol-http:2025-1",
   "transferType": "HttpData-PULL"
 }

--- a/federated-catalog/fc-01-embedded/README.md
+++ b/federated-catalog/fc-01-embedded/README.md
@@ -115,7 +115,7 @@ Sample output:
       
     },
     "dspace:participantId": "provider",
-    "originator": "http://localhost:19194/protocol",
+    "originator": "http://localhost:19194/protocol/2025-1",
     "@context": {
     }
   }

--- a/federated-catalog/fc-02-standalone/README.md
+++ b/federated-catalog/fc-02-standalone/README.md
@@ -98,7 +98,7 @@ Sample output:
       
     },
     "dspace:participantId": "provider",
-    "originator": "http://localhost:19194/protocol",
+    "originator": "http://localhost:19194/protocol/2025-1",
     "@context": {
       
     }

--- a/federated-catalog/fc-03-static-node-directory/README.md
+++ b/federated-catalog/fc-03-static-node-directory/README.md
@@ -36,8 +36,8 @@ In this case, the file contains the properties of the `participant-connector` fr
 {
     "name": "https://w3id.org/edc/v0.0.1/ns/",
     "id": "provider",
-    "url": "http://localhost:19194/protocol",
-    "supportedProtocols": ["dataspace-protocol-http"]
+    "url": "http://localhost:19194/protocol/2025-1",
+    "supportedProtocols": ["dataspace-protocol-http:2025-1"]
 }
 ```
 However, this solution is intended for use only within the sample scope; in production, it must be managed in different way.

--- a/policy/policy-01-policy-enforcement/README.md
+++ b/policy/policy-01-policy-enforcement/README.md
@@ -272,7 +272,7 @@ We'll receive the following catalog in the response, where we can see the offer 
     "@id": "fe9581ee-b4ec-473c-b0b7-96f30d957e87",
     "@type": "dcat:DataService",
     "dct:terms": "connector",
-    "dct:endpointUrl": "http://localhost:8282/protocol"
+    "dct:endpointUrl": "http://localhost:8282/protocol/2025-1"
   },
   "participantId": "provider",
   "@context": {
@@ -281,7 +281,7 @@ We'll receive the following catalog in the response, where we can see the offer 
     "dcat": "https://www.w3.org/ns/dcat/",
     "dct": "https://purl.org/dc/terms/",
     "odrl": "http://www.w3.org/ns/odrl/2/",
-    "dspace": "https://w3id.org/dspace/v0.8/"
+    "dspace": "https://w3id.org/dspace/2025/1/"
   }
 }
 

--- a/policy/policy-01-policy-enforcement/resources/catalog-request.json
+++ b/policy/policy-01-policy-enforcement/resources/catalog-request.json
@@ -2,6 +2,7 @@
   "@context": {
     "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
   },
-  "counterPartyAddress": "http://localhost:19194/protocol",
-  "protocol": "dataspace-protocol-http"
+  "counterPartyId": "provider",
+  "counterPartyAddress": "http://localhost:19194/protocol/2025-1",
+  "protocol": "dataspace-protocol-http:2025-1"
 }

--- a/policy/policy-01-policy-enforcement/resources/contract-request.json
+++ b/policy/policy-01-policy-enforcement/resources/contract-request.json
@@ -3,8 +3,9 @@
     "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
   },
   "@type": "ContractRequest",
-  "counterPartyAddress": "http://localhost:19194/protocol",
-  "protocol": "dataspace-protocol-http",
+  "counterPartyId": "provider",
+  "counterPartyAddress": "http://localhost:19194/protocol/2025-1",
+  "protocol": "dataspace-protocol-http:2025-1",
   "policy": {
     "@context": "http://www.w3.org/ns/odrl.jsonld",
     "@id": "1:test-document:13dce0f1-52ed-4554-a194-e83e92733ee5",

--- a/system-tests/src/test/java/org/eclipse/edc/samples/common/FileTransferCloudCommon.java
+++ b/system-tests/src/test/java/org/eclipse/edc/samples/common/FileTransferCloudCommon.java
@@ -21,6 +21,7 @@ import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.samples.common.FileTransferCommon.getFileContentFromRelativePath;
 import static org.eclipse.edc.samples.util.TransferUtil.POLL_INTERVAL;
 import static org.eclipse.edc.samples.util.TransferUtil.TIMEOUT;
+import static org.eclipse.edc.samples.util.TransferUtil.extractContractOfferId;
 import static org.eclipse.edc.samples.util.TransferUtil.get;
 import static org.eclipse.edc.samples.util.TransferUtil.post;
 
@@ -29,7 +30,6 @@ public class FileTransferCloudCommon {
     private static final String CONSUMER_MANAGEMENT_URL = "http://localhost:29193/management";
     private static final String V3_CATALOG_DATASET_REQUEST_PATH = "/v3/catalog/dataset/request";
     private static final String FETCH_DATASET_FROM_CATALOG_FILE_PATH = "transfer/transfer-05-file-transfer-cloud/resources/get-dataset.json";
-    private static final String CATALOG_DATASET_ID = "\"odrl:hasPolicy\".'@id'";
     private static final String NEGOTIATE_CONTRACT_FILE_PATH = "transfer/transfer-05-file-transfer-cloud/resources/negotiate-contract.json";
     private static final String V3_CONTRACT_NEGOTIATIONS_PATH = "/v3/contractnegotiations/";
     private static final String CONTRACT_NEGOTIATION_ID = "@id";
@@ -37,11 +37,11 @@ public class FileTransferCloudCommon {
     private static final String CONTRACT_OFFER_ID_KEY = "{{contract-offer-id}}";
 
     public static String fetchDatasetFromCatalog(String fetchDatasetFromCatalogFilePath) {
-        var catalogDatasetId = post(
+        var response = post(
                 CONSUMER_MANAGEMENT_URL + V3_CATALOG_DATASET_REQUEST_PATH,
-                getFileContentFromRelativePath(fetchDatasetFromCatalogFilePath),
-                CATALOG_DATASET_ID
+                getFileContentFromRelativePath(fetchDatasetFromCatalogFilePath)
         );
+        var catalogDatasetId = extractContractOfferId(response);
         assertThat(catalogDatasetId).isNotEmpty();
         return catalogDatasetId;
     }

--- a/system-tests/src/test/java/org/eclipse/edc/samples/common/FileTransferCloudCommon.java
+++ b/system-tests/src/test/java/org/eclipse/edc/samples/common/FileTransferCloudCommon.java
@@ -21,7 +21,6 @@ import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.samples.common.FileTransferCommon.getFileContentFromRelativePath;
 import static org.eclipse.edc.samples.util.TransferUtil.POLL_INTERVAL;
 import static org.eclipse.edc.samples.util.TransferUtil.TIMEOUT;
-import static org.eclipse.edc.samples.util.TransferUtil.extractContractOfferId;
 import static org.eclipse.edc.samples.util.TransferUtil.get;
 import static org.eclipse.edc.samples.util.TransferUtil.post;
 
@@ -30,6 +29,7 @@ public class FileTransferCloudCommon {
     private static final String CONSUMER_MANAGEMENT_URL = "http://localhost:29193/management";
     private static final String V3_CATALOG_DATASET_REQUEST_PATH = "/v3/catalog/dataset/request";
     private static final String FETCH_DATASET_FROM_CATALOG_FILE_PATH = "transfer/transfer-05-file-transfer-cloud/resources/get-dataset.json";
+    private static final String CATALOG_DATASET_ID = "\"hasPolicy\"[0].'@id'";
     private static final String NEGOTIATE_CONTRACT_FILE_PATH = "transfer/transfer-05-file-transfer-cloud/resources/negotiate-contract.json";
     private static final String V3_CONTRACT_NEGOTIATIONS_PATH = "/v3/contractnegotiations/";
     private static final String CONTRACT_NEGOTIATION_ID = "@id";
@@ -37,11 +37,11 @@ public class FileTransferCloudCommon {
     private static final String CONTRACT_OFFER_ID_KEY = "{{contract-offer-id}}";
 
     public static String fetchDatasetFromCatalog(String fetchDatasetFromCatalogFilePath) {
-        var response = post(
+        var catalogDatasetId = post(
                 CONSUMER_MANAGEMENT_URL + V3_CATALOG_DATASET_REQUEST_PATH,
-                getFileContentFromRelativePath(fetchDatasetFromCatalogFilePath)
+                getFileContentFromRelativePath(fetchDatasetFromCatalogFilePath),
+                CATALOG_DATASET_ID
         );
-        var catalogDatasetId = extractContractOfferId(response);
         assertThat(catalogDatasetId).isNotEmpty();
         return catalogDatasetId;
     }

--- a/system-tests/src/test/java/org/eclipse/edc/samples/common/NegotiationCommon.java
+++ b/system-tests/src/test/java/org/eclipse/edc/samples/common/NegotiationCommon.java
@@ -15,7 +15,6 @@
 
 package org.eclipse.edc.samples.common;
 
-
 import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,7 +22,6 @@ import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.samples.common.FileTransferCommon.getFileContentFromRelativePath;
 import static org.eclipse.edc.samples.util.TransferUtil.POLL_INTERVAL;
 import static org.eclipse.edc.samples.util.TransferUtil.TIMEOUT;
-import static org.eclipse.edc.samples.util.TransferUtil.extractContractOfferId;
 import static org.eclipse.edc.samples.util.TransferUtil.get;
 import static org.eclipse.edc.samples.util.TransferUtil.post;
 
@@ -37,6 +35,7 @@ public class NegotiationCommon {
     private static final String V2_CONTRACT_DEFINITIONS_PATH = "/v3/contractdefinitions";
     private static final String V2_CATALOG_DATASET_REQUEST_PATH = "/v3/catalog/dataset/request";
     private static final String FETCH_DATASET_FROM_CATALOG_FILE_PATH = "transfer/transfer-01-negotiation/resources/get-dataset.json";
+    private static final String CATALOG_DATASET_ID = "\"hasPolicy\"[0].'@id'";
     private static final String NEGOTIATE_CONTRACT_FILE_PATH = "transfer/transfer-01-negotiation/resources/negotiate-contract.json";
     private static final String V2_CONTRACT_NEGOTIATIONS_PATH = "/v3/contractnegotiations/";
     private static final String CONTRACT_NEGOTIATION_ID = "@id";
@@ -56,11 +55,11 @@ public class NegotiationCommon {
     }
 
     public static String fetchDatasetFromCatalog(String fetchDatasetFromCatalogFilePath) {
-        var response = post(
+        var catalogDatasetId = post(
                 PrerequisitesCommon.CONSUMER_MANAGEMENT_URL + V2_CATALOG_DATASET_REQUEST_PATH,
-                getFileContentFromRelativePath(fetchDatasetFromCatalogFilePath)
+                getFileContentFromRelativePath(fetchDatasetFromCatalogFilePath),
+                CATALOG_DATASET_ID
         );
-        var catalogDatasetId = extractContractOfferId(response);
         assertThat(catalogDatasetId).isNotEmpty();
         return catalogDatasetId;
     }

--- a/system-tests/src/test/java/org/eclipse/edc/samples/common/NegotiationCommon.java
+++ b/system-tests/src/test/java/org/eclipse/edc/samples/common/NegotiationCommon.java
@@ -23,6 +23,7 @@ import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.samples.common.FileTransferCommon.getFileContentFromRelativePath;
 import static org.eclipse.edc.samples.util.TransferUtil.POLL_INTERVAL;
 import static org.eclipse.edc.samples.util.TransferUtil.TIMEOUT;
+import static org.eclipse.edc.samples.util.TransferUtil.extractContractOfferId;
 import static org.eclipse.edc.samples.util.TransferUtil.get;
 import static org.eclipse.edc.samples.util.TransferUtil.post;
 
@@ -36,7 +37,6 @@ public class NegotiationCommon {
     private static final String V2_CONTRACT_DEFINITIONS_PATH = "/v3/contractdefinitions";
     private static final String V2_CATALOG_DATASET_REQUEST_PATH = "/v3/catalog/dataset/request";
     private static final String FETCH_DATASET_FROM_CATALOG_FILE_PATH = "transfer/transfer-01-negotiation/resources/get-dataset.json";
-    private static final String CATALOG_DATASET_ID = "\"odrl:hasPolicy\".'@id'";
     private static final String NEGOTIATE_CONTRACT_FILE_PATH = "transfer/transfer-01-negotiation/resources/negotiate-contract.json";
     private static final String V2_CONTRACT_NEGOTIATIONS_PATH = "/v3/contractnegotiations/";
     private static final String CONTRACT_NEGOTIATION_ID = "@id";
@@ -56,11 +56,11 @@ public class NegotiationCommon {
     }
 
     public static String fetchDatasetFromCatalog(String fetchDatasetFromCatalogFilePath) {
-        var catalogDatasetId = post(
+        var response = post(
                 PrerequisitesCommon.CONSUMER_MANAGEMENT_URL + V2_CATALOG_DATASET_REQUEST_PATH,
-                getFileContentFromRelativePath(fetchDatasetFromCatalogFilePath),
-                CATALOG_DATASET_ID
+                getFileContentFromRelativePath(fetchDatasetFromCatalogFilePath)
         );
+        var catalogDatasetId = extractContractOfferId(response);
         assertThat(catalogDatasetId).isNotEmpty();
         return catalogDatasetId;
     }

--- a/system-tests/src/test/java/org/eclipse/edc/samples/transfer/StreamingParticipant.java
+++ b/system-tests/src/test/java/org/eclipse/edc/samples/transfer/StreamingParticipant.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.samples.transfer;
 
 import org.eclipse.edc.connector.controlplane.test.system.utils.Participant;
 import org.eclipse.edc.junit.utils.LazySupplier;
+import org.eclipse.edc.samples.util.TransferUtil;
 
 import java.net.URI;
 
@@ -72,15 +73,14 @@ public class StreamingParticipant extends Participant {
     }
 
     public String fetchDatasetFromCatalog(String requestBody) {
-        return baseManagementRequest()
+        return TransferUtil.extractContractOfferId(baseManagementRequest()
                 .contentType(JSON)
                 .body(requestBody)
                 .when()
                 .post("/v3/catalog/dataset/request")
                 .then()
                 .statusCode(200)
-                .contentType(JSON)
-                .extract().jsonPath().getString("'odrl:hasPolicy'.@id");
+                .contentType(JSON));
     }
 
     public String negotiateContract(String requestBody) {

--- a/system-tests/src/test/java/org/eclipse/edc/samples/transfer/StreamingParticipant.java
+++ b/system-tests/src/test/java/org/eclipse/edc/samples/transfer/StreamingParticipant.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.samples.transfer;
 
 import org.eclipse.edc.connector.controlplane.test.system.utils.Participant;
 import org.eclipse.edc.junit.utils.LazySupplier;
-import org.eclipse.edc.samples.util.TransferUtil;
 
 import java.net.URI;
 
@@ -27,7 +26,6 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
  * Essentially a wrapper around the management API enabling to test interactions with other participants, eg. catalog, transfer...
  */
 public class StreamingParticipant extends Participant {
-
     protected StreamingParticipant() {
     }
 
@@ -73,14 +71,15 @@ public class StreamingParticipant extends Participant {
     }
 
     public String fetchDatasetFromCatalog(String requestBody) {
-        return TransferUtil.extractContractOfferId(baseManagementRequest()
+        return baseManagementRequest()
                 .contentType(JSON)
                 .body(requestBody)
                 .when()
                 .post("/v3/catalog/dataset/request")
                 .then()
                 .statusCode(200)
-                .contentType(JSON));
+                .contentType(JSON)
+                .extract().jsonPath().getString("hasPolicy[0].@id");
     }
 
     public String negotiateContract(String requestBody) {

--- a/system-tests/src/test/java/org/eclipse/edc/samples/transfer/Transfer06KafkaBrokerTest.java
+++ b/system-tests/src/test/java/org/eclipse/edc/samples/transfer/Transfer06KafkaBrokerTest.java
@@ -90,13 +90,13 @@ public class Transfer06KafkaBrokerTest {
             .name("provider")
             .id("provider")
             .controlPlaneManagement(new LazySupplier<>(() -> URI.create("http://localhost:18181/management")))
-            .controlPlaneProtocol(new LazySupplier<>(() -> URI.create("http://localhost:18182/protocol")))
+            .controlPlaneProtocol(new LazySupplier<>(() -> URI.create("http://localhost:18182/protocol/2025-1")))
             .build();
     private static final StreamingParticipant CONSUMER = StreamingParticipant.Builder.newStreamingInstance()
             .name("consumer")
             .id("consumer")
             .controlPlaneManagement(new LazySupplier<>(() -> URI.create("http://localhost:28181/management")))
-            .controlPlaneProtocol(new LazySupplier<>(() -> URI.create("http://localhost:28182/protocol")))
+            .controlPlaneProtocol(new LazySupplier<>(() -> URI.create("http://localhost:28182/protocol/2025-1")))
             .build();
     private static final String GROUP_ID = "group_id";
 

--- a/system-tests/src/test/java/org/eclipse/edc/samples/util/TransferUtil.java
+++ b/system-tests/src/test/java/org/eclipse/edc/samples/util/TransferUtil.java
@@ -15,9 +15,6 @@
 
 package org.eclipse.edc.samples.util;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
 import org.apache.http.HttpStatus;
@@ -40,7 +37,6 @@ public class TransferUtil {
     public static final Duration TIMEOUT = Duration.ofSeconds(30);
     public static final Duration POLL_DELAY = Duration.ofMillis(1000);
     public static final Duration POLL_INTERVAL = Duration.ofMillis(500);
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private static final String CONTRACT_AGREEMENT_ID_KEY = "{{contract-agreement-id}}";
     private static final String V2_TRANSFER_PROCESSES_PATH = "/v3/transferprocesses/";
@@ -92,36 +88,6 @@ public class TransferUtil {
                 .get(jsonPath);
     }
 
-    public static String extractContractOfferId(ValidatableResponse response) {
-        try {
-            var body = response.extract().asString();
-            var root = OBJECT_MAPPER.readTree(body);
-            var offerId = readPolicyId(root, "odrl:hasPolicy");
-            if (offerId != null) {
-                return offerId;
-            }
-
-            offerId = readPolicyId(root, "hasPolicy");
-            if (offerId != null) {
-                return offerId;
-            }
-
-            offerId = readPolicyId(root, "dcat:dataset", "odrl:hasPolicy");
-            if (offerId != null) {
-                return offerId;
-            }
-
-            offerId = readPolicyId(root, "dcat:dataset", "hasPolicy");
-            if (offerId != null) {
-                return offerId;
-            }
-
-            throw new IllegalStateException("Cannot extract contract offer id from response: " + body);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     public static String startTransfer(String requestBody, String contractAgreementId) {
         requestBody = requestBody.replace(CONTRACT_AGREEMENT_ID_KEY, contractAgreementId);
         return post(CONSUMER_MANAGEMENT_URL + V2_TRANSFER_PROCESSES_PATH, requestBody, ID);
@@ -136,24 +102,5 @@ public class TransferUtil {
                     var state = get(CONSUMER_MANAGEMENT_URL + V2_TRANSFER_PROCESSES_PATH + transferProcessId, EDC_STATE);
                     assertThat(state).isEqualTo(status.name());
                 });
-    }
-
-    private static String readText(JsonNode root, String... path) {
-        var node = root;
-        for (var key : path) {
-            node = node.path(key);
-        }
-        return node.isMissingNode() || node.isNull() ? null : node.asText();
-    }
-
-    private static String readPolicyId(JsonNode root, String... path) {
-        var node = root;
-        for (var key : path) {
-            node = node.path(key);
-        }
-        if (node.isArray()) {
-            node = node.isEmpty() ? null : node.get(0);
-        }
-        return node == null ? null : readText(node, ID);
     }
 }

--- a/system-tests/src/test/java/org/eclipse/edc/samples/util/TransferUtil.java
+++ b/system-tests/src/test/java/org/eclipse/edc/samples/util/TransferUtil.java
@@ -15,6 +15,9 @@
 
 package org.eclipse.edc.samples.util;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
 import org.apache.http.HttpStatus;
@@ -37,6 +40,7 @@ public class TransferUtil {
     public static final Duration TIMEOUT = Duration.ofSeconds(30);
     public static final Duration POLL_DELAY = Duration.ofMillis(1000);
     public static final Duration POLL_INTERVAL = Duration.ofMillis(500);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private static final String CONTRACT_AGREEMENT_ID_KEY = "{{contract-agreement-id}}";
     private static final String V2_TRANSFER_PROCESSES_PATH = "/v3/transferprocesses/";
@@ -88,6 +92,36 @@ public class TransferUtil {
                 .get(jsonPath);
     }
 
+    public static String extractContractOfferId(ValidatableResponse response) {
+        try {
+            var body = response.extract().asString();
+            var root = OBJECT_MAPPER.readTree(body);
+            var offerId = readPolicyId(root, "odrl:hasPolicy");
+            if (offerId != null) {
+                return offerId;
+            }
+
+            offerId = readPolicyId(root, "hasPolicy");
+            if (offerId != null) {
+                return offerId;
+            }
+
+            offerId = readPolicyId(root, "dcat:dataset", "odrl:hasPolicy");
+            if (offerId != null) {
+                return offerId;
+            }
+
+            offerId = readPolicyId(root, "dcat:dataset", "hasPolicy");
+            if (offerId != null) {
+                return offerId;
+            }
+
+            throw new IllegalStateException("Cannot extract contract offer id from response: " + body);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public static String startTransfer(String requestBody, String contractAgreementId) {
         requestBody = requestBody.replace(CONTRACT_AGREEMENT_ID_KEY, contractAgreementId);
         return post(CONSUMER_MANAGEMENT_URL + V2_TRANSFER_PROCESSES_PATH, requestBody, ID);
@@ -102,5 +136,24 @@ public class TransferUtil {
                     var state = get(CONSUMER_MANAGEMENT_URL + V2_TRANSFER_PROCESSES_PATH + transferProcessId, EDC_STATE);
                     assertThat(state).isEqualTo(status.name());
                 });
+    }
+
+    private static String readText(JsonNode root, String... path) {
+        var node = root;
+        for (var key : path) {
+            node = node.path(key);
+        }
+        return node.isMissingNode() || node.isNull() ? null : node.asText();
+    }
+
+    private static String readPolicyId(JsonNode root, String... path) {
+        var node = root;
+        for (var key : path) {
+            node = node.path(key);
+        }
+        if (node.isArray()) {
+            node = node.isEmpty() ? null : node.get(0);
+        }
+        return node == null ? null : readText(node, ID);
     }
 }

--- a/transfer/transfer-01-negotiation/README.md
+++ b/transfer/transfer-01-negotiation/README.md
@@ -143,7 +143,7 @@ Sample output:
     "@id": "2a5178c3-c937-4ac2-85be-c46dbc6c5642",
     "@type": "dcat:DataService",
     "dct:terms": "connector",
-    "dct:endpointUrl": "http://localhost:19194/protocol"
+    "dct:endpointUrl": "http://localhost:19194/protocol/2025-1"
   },
   "participantId": "anonymous",
   "@context": {
@@ -151,7 +151,7 @@ Sample output:
     "dct": "https://purl.org/dc/terms/",
     "dcat": "https://www.w3.org/ns/dcat/",
     "odrl": "http://www.w3.org/ns/odrl/2/",
-    "dspace": "https://w3id.org/dspace/v0.8/"
+    "dspace": "https://w3id.org/dspace/2025/1/"
   }
 }
 ```
@@ -216,9 +216,9 @@ Sample output:
   "@type": "ContractNegotiation",
   "@id": "5ca21b82-075b-4682-add8-c26c9a2ced67",
   "type": "CONSUMER",
-  "protocol": "dataspace-protocol-http",
+  "protocol": "dataspace-protocol-http:2025-1",
   "state": "FINALIZED",
-  "counterPartyAddress": "http://localhost:19194/protocol",
+  "counterPartyAddress": "http://localhost:19194/protocol/2025-1",
   "callbackAddresses": [],
   "contractAgreementId": "0b3150be-feaf-43bc-91e1-90f050de28bd",  <---------
   "@context": {
@@ -226,7 +226,7 @@ Sample output:
     "dct": "https://purl.org/dc/terms/",
     "dcat": "https://www.w3.org/ns/dcat/",
     "odrl": "http://www.w3.org/ns/odrl/2/",
-    "dspace": "https://w3id.org/dspace/v0.8/"
+    "dspace": "https://w3id.org/dspace/2025/1/"
   }
 }
 ```

--- a/transfer/transfer-01-negotiation/resources/fetch-catalog.json
+++ b/transfer/transfer-01-negotiation/resources/fetch-catalog.json
@@ -2,6 +2,7 @@
   "@context": {
     "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
   },
-  "counterPartyAddress": "http://localhost:19194/protocol",
-  "protocol": "dataspace-protocol-http"
+  "counterPartyId": "provider",
+  "counterPartyAddress": "http://localhost:19194/protocol/2025-1",
+  "protocol": "dataspace-protocol-http:2025-1"
 }

--- a/transfer/transfer-01-negotiation/resources/get-dataset.json
+++ b/transfer/transfer-01-negotiation/resources/get-dataset.json
@@ -2,6 +2,7 @@
   "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
   "@type": "DatasetRequest",
   "@id": "assetId",
-  "counterPartyAddress": "http://localhost:19194/protocol",
-  "protocol": "dataspace-protocol-http"
+  "counterPartyId": "provider",
+  "counterPartyAddress": "http://localhost:19194/protocol/2025-1",
+  "protocol": "dataspace-protocol-http:2025-1"
 }

--- a/transfer/transfer-01-negotiation/resources/negotiate-contract.json
+++ b/transfer/transfer-01-negotiation/resources/negotiate-contract.json
@@ -3,8 +3,9 @@
     "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
   },
   "@type": "ContractRequest",
-  "counterPartyAddress": "http://localhost:19194/protocol",
-  "protocol": "dataspace-protocol-http",
+  "counterPartyId": "provider",
+  "counterPartyAddress": "http://localhost:19194/protocol/2025-1",
+  "protocol": "dataspace-protocol-http:2025-1",
   "policy": {
     "@context": "http://www.w3.org/ns/odrl.jsonld",
     "@id": "{{contract-offer-id}}",

--- a/transfer/transfer-02-provider-push/resources/start-transfer.json
+++ b/transfer/transfer-02-provider-push/resources/start-transfer.json
@@ -4,9 +4,9 @@
   },
   "@type": "TransferRequestDto",
   "connectorId": "provider",
-  "counterPartyAddress": "http://localhost:19194/protocol",
+  "counterPartyAddress": "http://localhost:19194/protocol/2025-1",
   "contractId": "{{contract-agreement-id}}",
-  "protocol": "dataspace-protocol-http",
+  "protocol": "dataspace-protocol-http:2025-1",
   "transferType": "HttpData-PUSH",
   "dataDestination": {
     "type": "HttpData",

--- a/transfer/transfer-03-consumer-pull/resources/start-transfer.json
+++ b/transfer/transfer-03-consumer-pull/resources/start-transfer.json
@@ -4,8 +4,8 @@
   },
   "@type": "TransferRequestDto",
   "connectorId": "provider",
-  "counterPartyAddress": "http://localhost:19194/protocol",
+  "counterPartyAddress": "http://localhost:19194/protocol/2025-1",
   "contractId": "{{contract-agreement-id}}",
-  "protocol": "dataspace-protocol-http",
+  "protocol": "dataspace-protocol-http:2025-1",
   "transferType": "HttpData-PULL"
 }

--- a/transfer/transfer-05-file-transfer-cloud/resources/fetch-catalog.json
+++ b/transfer/transfer-05-file-transfer-cloud/resources/fetch-catalog.json
@@ -2,6 +2,7 @@
   "@context": {
     "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
   },
-  "counterPartyAddress": "http://localhost:19194/protocol",
-  "protocol": "dataspace-protocol-http"
+  "counterPartyId": "provider",
+  "counterPartyAddress": "http://localhost:19194/protocol/2025-1",
+  "protocol": "dataspace-protocol-http:2025-1"
 }

--- a/transfer/transfer-05-file-transfer-cloud/resources/get-dataset.json
+++ b/transfer/transfer-05-file-transfer-cloud/resources/get-dataset.json
@@ -2,6 +2,7 @@
     "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/"},
     "@type": "DatasetRequest",
     "@id": "1",
-    "counterPartyAddress": "http://localhost:19194/protocol",
-    "protocol": "dataspace-protocol-http"
+    "counterPartyId": "provider",
+    "counterPartyAddress": "http://localhost:19194/protocol/2025-1",
+    "protocol": "dataspace-protocol-http:2025-1"
 }

--- a/transfer/transfer-05-file-transfer-cloud/resources/negotiate-contract.json
+++ b/transfer/transfer-05-file-transfer-cloud/resources/negotiate-contract.json
@@ -3,8 +3,9 @@
     "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
   },
   "@type": "ContractRequest",
-  "counterPartyAddress": "http://localhost:19194/protocol",
-  "protocol": "dataspace-protocol-http",
+  "counterPartyId": "provider",
+  "counterPartyAddress": "http://localhost:19194/protocol/2025-1",
+  "protocol": "dataspace-protocol-http:2025-1",
   "policy": {
     "@context": "http://www.w3.org/ns/odrl.jsonld",
     "@id": "{{contract-offer-id}}",

--- a/transfer/transfer-05-file-transfer-cloud/resources/start-transfer.json
+++ b/transfer/transfer-05-file-transfer-cloud/resources/start-transfer.json
@@ -4,9 +4,9 @@
   },
   "@type": "TransferRequestDto",
   "connectorId": "provider",
-  "counterPartyAddress": "http://localhost:19194/protocol",
+  "counterPartyAddress": "http://localhost:19194/protocol/2025-1",
   "contractId": "{{contract-agreement-id}}",
-  "protocol": "dataspace-protocol-http",
+  "protocol": "dataspace-protocol-http:2025-1",
   "transferType": "AmazonS3-PUSH",
   "dataDestination": {
     "type": "AmazonS3",

--- a/transfer/transfer-06-kafka-broker/4-get-dataset.json
+++ b/transfer/transfer-06-kafka-broker/4-get-dataset.json
@@ -2,6 +2,7 @@
   "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
   "@type": "DatasetRequest",
   "@id": "kafka-stream-asset",
-  "counterPartyAddress": "http://localhost:18182/protocol",
-  "protocol": "dataspace-protocol-http"
+  "counterPartyId": "provider",
+  "counterPartyAddress": "http://localhost:18182/protocol/2025-1",
+  "protocol": "dataspace-protocol-http:2025-1"
 }

--- a/transfer/transfer-06-kafka-broker/5-negotiate-contract.json
+++ b/transfer/transfer-06-kafka-broker/5-negotiate-contract.json
@@ -3,8 +3,9 @@
     "edc": "https://w3id.org/edc/v0.0.1/ns/"
   },
   "@type": "ContractRequest",
-  "counterPartyAddress": "http://localhost:18182/protocol",
-  "protocol": "dataspace-protocol-http",
+  "counterPartyId": "provider",
+  "counterPartyAddress": "http://localhost:18182/protocol/2025-1",
+  "protocol": "dataspace-protocol-http:2025-1",
   "policy": {
     "@context": "http://www.w3.org/ns/odrl.jsonld",
     "@id": "{{offerId}}",

--- a/transfer/transfer-06-kafka-broker/6-transfer.json
+++ b/transfer/transfer-06-kafka-broker/6-transfer.json
@@ -3,11 +3,11 @@
     "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
   },
   "@type": "TransferRequest",
-  "protocol": "dataspace-protocol-http",
+  "protocol": "dataspace-protocol-http:2025-1",
   "transferType": "KafkaBroker-PULL",
   "contractId": "{{contract-agreement-id}}",
   "connectorId": "provider",
-  "counterPartyAddress": "http://localhost:18182/protocol",
+  "counterPartyAddress": "http://localhost:18182/protocol/2025-1",
   "callbackAddresses": [
     {
       "transactional": false,

--- a/transfer/transfer-06-kafka-broker/README.md
+++ b/transfer/transfer-06-kafka-broker/README.md
@@ -131,7 +131,7 @@ The output will be something like:
     "edc": "https://w3id.org/edc/v0.0.1/ns/",
     "dcat": "https://www.w3.org/ns/dcat/",
     "odrl": "http://www.w3.org/ns/odrl/2/",
-    "dspace": "https://w3id.org/dspace/v0.8/"
+    "dspace": "https://w3id.org/dspace/2025/1/"
   }
 }
 ```


### PR DESCRIPTION
## What this PR changes/adds

This PR is to upgrade the samples to use DSP 2025/1 instead of the old 0.8

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #515

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
